### PR TITLE
EI-116-timeout-error-in-test

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "infra": "docker compose -f docker-compose-api.yml up",
-    "test": "jest",
+    "test": "jest --testTimeout=10000",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",


### PR DESCRIPTION
**오류메세지**
thrown: "Exceeded timeout of 5000 ms for a test.

**작업 내용**
여러번 테스트를 시행한 결과, krx adapter와 redis adapter에서 가끔 위와 같은 오류가 발생했습니다. 두 통합 테스트 코드의 테스트 시간이 상대적으로 오래걸려 발생한 오류입니다. 

상대적으로 시간이 오래걸리는 두 테스트 코드 각각의 테스트 시간을 줄이는 것보다 global하게 testTime에 여유를 주는 방식을 선택했습니다.