### PR TITLE
[EI-120] [web] test: Add IconButton component snapshot tests

### DIFF
--- a/web/__tests__/components/view/atom/__snapshots__/icon-button.tsx.snap
+++ b/web/__tests__/components/view/atom/__snapshots__/icon-button.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IconButton default 옵션의 아이콘 버튼을 렌더링한다. 1`] = `
+<div>
+  <button
+    class="px-1.5 py-1.5 text-blue-500"
+  >
+    <svg
+      aria-hidden="true"
+      class="h-5 w-5"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M6 10a2 2 0 11-4 0 2 2 0 014 0zM12 10a2 2 0 11-4 0 2 2 0 014 0zM16 12a2 2 0 100-4 2 2 0 000 4z"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`IconButton outlined 스타일의 아이콘 버튼을 렌더링한다. 1`] = `
+<div>
+  <button
+    class="px-1.5 py-1.5 bg-white bg-opacity-20 border-blue-500 ring-blue-300 ring-opacity-40 text-blue-500 hover:bg-blue-500 hover:bg-opacity-20 hover:text-blue-500 border ring-2 rounded-lg"
+  >
+    <svg
+      aria-hidden="true"
+      class="h-5 w-5"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M6 10a2 2 0 11-4 0 2 2 0 014 0zM12 10a2 2 0 11-4 0 2 2 0 014 0zM16 12a2 2 0 100-4 2 2 0 000 4z"
+      />
+    </svg>
+  </button>
+</div>
+`;

--- a/web/__tests__/components/view/atom/icon-button.tsx
+++ b/web/__tests__/components/view/atom/icon-button.tsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react';
+import IconButton from '@/app/ui/components/view/atom/icon-button/icon-button';
+import { DotsHorizontalIcon } from '@heroicons/react/solid';
+
+describe('IconButton', () => {
+  it('default 옵션의 아이콘 버튼을 렌더링한다.', () => {
+    const { container } = render(<IconButton icon={DotsHorizontalIcon} color={'blue'} />);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('outlined 스타일의 아이콘 버튼을 렌더링한다.', () => {
+    const { container } = render(<IconButton icon={DotsHorizontalIcon} color={'blue'} invariant={'outlined'} />);
+
+    expect(container).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
✅ 작업 내용
- icon button에 대한 스냅샷 테스트를 작성했습니다

## 🤔 고민 했던 부분
- icon button은 design system 적으로 설계된 범용성 있는 atom 컴포넌트입니다
- 따라서 어떤 테스트가 적합할지 고민이 필요했습니다.
- atom 컴포넌트의 특성 상 로직보다는 스타일을 표현하기 때문에 snapshot 테스트가 적당하다고 생각했습니다
- 추후 storybook을 통한 시각적 테스트도 고려 대상입니다
