### PR TITLE
[Ei-132] 지표보드 메타데이터에 지표 추가

### DIFF
--- a/api/src/numerical-guidance/api/dto/create-indicator-board-metadata.dto.ts
+++ b/api/src/numerical-guidance/api/dto/create-indicator-board-metadata.dto.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsNotEmpty, IsObject, IsString } from 'class-validator';
+import { IsInt, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateIndicatorBoardMetadataDto {
@@ -8,14 +8,6 @@ export class CreateIndicatorBoardMetadataDto {
   })
   @IsString()
   indicatorBoardMetaDataName: string;
-
-  @ApiProperty({
-    example: '{"key1": ["1", "2", "3", "4", "5"]}',
-    description: '지표의 식별값들',
-  })
-  @IsObject()
-  @IsNotEmpty()
-  readonly indicatorIds: Record<string, string[]>;
 
   @ApiProperty({
     example: '1',

--- a/api/src/numerical-guidance/api/dto/insert-indicator.dto.ts
+++ b/api/src/numerical-guidance/api/dto/insert-indicator.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+import { IndicatorType } from '../../application/query/get-fluctuatingIndicator/fluctuatingIndicator.dto';
+
+export class InsertIndicatorDto {
+  @ApiProperty({
+    example: '005930',
+    description: '지표 식별값',
+  })
+  @IsString()
+  readonly ticker: string;
+
+  @ApiProperty({
+    example: 'k-stock | exchange',
+    description: '지표의 타입',
+  })
+  @IsString()
+  readonly type: IndicatorType;
+}

--- a/api/src/numerical-guidance/api/numerical-guidance.controller.ts
+++ b/api/src/numerical-guidance/api/numerical-guidance.controller.ts
@@ -13,6 +13,8 @@ import { CreateIndicatorBoardMetadataCommand } from '../application/command/crea
 import { Response } from 'express';
 import { GetIndicatorBoardMetadataQuery } from '../application/query/get-indicator-board-metadata/get-indicator-board-metadata.query';
 import { IndicatorBoardMetadata } from '../domain/indicator-board-metadata';
+import { InsertIndicatorTickerCommand } from '../application/command/insert-indicator-ticker/insert-indicator-ticker.command';
+import { InsertIndicatorDto } from './dto/insert-indicator.dto';
 
 @ApiTags('NumericalGuidanceController')
 @Controller('/numerical-guidance')
@@ -67,7 +69,6 @@ export class NumericalGuidanceController {
   ) {
     const command = new CreateIndicatorBoardMetadataCommand(
       createIndicatorBoardMetaDataDto.indicatorBoardMetaDataName,
-      createIndicatorBoardMetaDataDto.indicatorIds,
       createIndicatorBoardMetaDataDto.memberId,
     );
     await this.commandBus.execute(command);
@@ -79,5 +80,13 @@ export class NumericalGuidanceController {
   async getIndicatorBoardMetaDataById(@Param('id') id): Promise<IndicatorBoardMetadata> {
     const query = new GetIndicatorBoardMetadataQuery(id);
     return await this.queryBus.execute(query);
+  }
+
+  @ApiOperation({ summary: '지표보드 메타데이터에 지표 ticker 추가합니다.' })
+  @Post('/indicator-board-metadata/:id')
+  async insertNewIndicatorTicker(@Param('id') id, @Body() insertIndicatorDto: InsertIndicatorDto) {
+    const command = new InsertIndicatorTickerCommand(id, insertIndicatorDto.ticker, insertIndicatorDto.type);
+
+    await this.commandBus.execute(command);
   }
 }

--- a/api/src/numerical-guidance/application/command/create-indicator-board-metadata/create-indicator-board-metadata.command.handler.ts
+++ b/api/src/numerical-guidance/application/command/create-indicator-board-metadata/create-indicator-board-metadata.command.handler.ts
@@ -15,11 +15,8 @@ export class CreateIndicatorBoardMetadataCommandHandler implements ICommandHandl
 
   @Transactional()
   async execute(command: CreateIndicatorBoardMetadataCommand): Promise<IndicatorBoardMetadata> {
-    const { indicatorBoardMetaDataName, indicatorIds, memberId } = command;
-    const indicatorBoardMetaData: IndicatorBoardMetadata = IndicatorBoardMetadata.createNew(
-      indicatorBoardMetaDataName,
-      indicatorIds,
-    );
+    const { indicatorBoardMetaDataName, memberId } = command;
+    const indicatorBoardMetaData: IndicatorBoardMetadata = IndicatorBoardMetadata.createNew(indicatorBoardMetaDataName);
 
     await this.createIndicatorBoardMetaDataPort.createIndicatorBoardMetaData(indicatorBoardMetaData, memberId);
 

--- a/api/src/numerical-guidance/application/command/create-indicator-board-metadata/create-indicator-board-metadata.command.ts
+++ b/api/src/numerical-guidance/application/command/create-indicator-board-metadata/create-indicator-board-metadata.command.ts
@@ -3,7 +3,6 @@ import { ICommand } from '@nestjs/cqrs';
 export class CreateIndicatorBoardMetadataCommand implements ICommand {
   constructor(
     readonly indicatorBoardMetaDataName: string,
-    readonly indicatorIds: Record<string, string[]>,
     readonly memberId: number,
   ) {}
 }

--- a/api/src/numerical-guidance/application/command/insert-indicator-ticker/insert-indicator-ticker.command.handler.ts
+++ b/api/src/numerical-guidance/application/command/insert-indicator-ticker/insert-indicator-ticker.command.handler.ts
@@ -1,0 +1,29 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { Inject, Injectable } from '@nestjs/common';
+import { InsertIndicatorTickerPort } from '../../port/persistence/insert-indicator-ticker.port';
+import { Transactional } from 'typeorm-transactional';
+import { InsertIndicatorTickerCommand } from './insert-indicator-ticker.command';
+import { LoadIndicatorBoardMetadataPort } from '../../port/persistence/load-indiactor-board-metadata.port';
+import { IndicatorBoardMetadata } from '../../../domain/indicator-board-metadata';
+
+@Injectable()
+@CommandHandler(InsertIndicatorTickerCommand)
+export class InsertIndicatorTickerCommandHandler implements ICommandHandler {
+  constructor(
+    @Inject('InsertIndicatorTickerPort')
+    private readonly insertIndicatorTickerPort: InsertIndicatorTickerPort,
+    @Inject('LoadIndicatorBoardMetadataPort')
+    private readonly loadIndicatorBoardMetaDataPort: LoadIndicatorBoardMetadataPort,
+  ) {}
+
+  @Transactional()
+  async execute(command: InsertIndicatorTickerCommand) {
+    const { id, ticker, type } = command;
+    const indicatorBoardMetaData: IndicatorBoardMetadata =
+      await this.loadIndicatorBoardMetaDataPort.loadIndicatorBoardMetaData(id);
+
+    indicatorBoardMetaData.insertIndicatorTicker(ticker, type);
+
+    await this.insertIndicatorTickerPort.addIndicatorTicker(indicatorBoardMetaData);
+  }
+}

--- a/api/src/numerical-guidance/application/command/insert-indicator-ticker/insert-indicator-ticker.command.ts
+++ b/api/src/numerical-guidance/application/command/insert-indicator-ticker/insert-indicator-ticker.command.ts
@@ -1,0 +1,9 @@
+import { ICommand } from '@nestjs/cqrs';
+
+export class InsertIndicatorTickerCommand implements ICommand {
+  constructor(
+    readonly id: string,
+    readonly ticker: string,
+    readonly type: string,
+  ) {}
+}

--- a/api/src/numerical-guidance/application/port/persistence/insert-indicator-ticker.port.ts
+++ b/api/src/numerical-guidance/application/port/persistence/insert-indicator-ticker.port.ts
@@ -1,0 +1,5 @@
+import { IndicatorBoardMetadata } from '../../../domain/indicator-board-metadata';
+
+export interface InsertIndicatorTickerPort {
+  addIndicatorTicker(indicatorBoardMetaData: IndicatorBoardMetadata): Promise<void>;
+}

--- a/api/src/numerical-guidance/domain/indicator-board-metadata.ts
+++ b/api/src/numerical-guidance/domain/indicator-board-metadata.ts
@@ -15,15 +15,10 @@ export class IndicatorBoardMetadata extends AggregateRoot {
   }
 
   public insertIndicatorTicker(ticker: string, type: string): void {
-    const newTickers: Record<string, string[]> = this.tickers;
-    if (this.tickers[type]?.length == 0) {
-      newTickers[type] = [ticker];
-    } else {
-      const indicatorTickers: string[] = newTickers[type]?.toString().split(',');
-      indicatorTickers?.push(ticker);
-      newTickers[type] = indicatorTickers;
-      console.log(indicatorTickers);
-    }
+    const newTickers: Record<string, string[]> = { ...this.tickers };
+    const currentTickers = newTickers[type] || [];
+    currentTickers.push(ticker);
+    newTickers[type] = currentTickers;
     this.checkRule(new NewIndicatorTypeShouldBelongToTheIndicatorTypeRule(newTickers));
     this.checkRule(new IndicatorBoardMetaDataCountShouldNotExceedLimitRule(newTickers));
     this.checkRule(new IndicatorInIndicatorBoardMetadataShouldNotDuplicateRule(newTickers));

--- a/api/src/numerical-guidance/domain/indicator-board-metadata.ts
+++ b/api/src/numerical-guidance/domain/indicator-board-metadata.ts
@@ -16,13 +16,20 @@ export class IndicatorBoardMetadata extends AggregateRoot {
 
   public insertIndicatorTicker(ticker: string, type: string): void {
     const newTickers: Record<string, string[]> = { ...this.tickers };
-    const currentTickers = newTickers[type] || [];
+    const currentTickers = this.convertToArray(newTickers[type]?.toString());
     currentTickers.push(ticker);
     newTickers[type] = currentTickers;
     this.checkRule(new NewIndicatorTypeShouldBelongToTheIndicatorTypeRule(newTickers));
-    this.checkRule(new IndicatorBoardMetaDataCountShouldNotExceedLimitRule(newTickers));
     this.checkRule(new IndicatorInIndicatorBoardMetadataShouldNotDuplicateRule(newTickers));
+    this.checkRule(new IndicatorBoardMetaDataCountShouldNotExceedLimitRule(newTickers));
     this.tickers = newTickers;
+  }
+
+  private convertToArray(tickers: string): string[] {
+    if (tickers) {
+      return tickers.split(',');
+    }
+    return [];
   }
 
   constructor(id: string, indicatorBoardMetaDataName: string, tickers: Record<string, string[]>) {

--- a/api/src/numerical-guidance/domain/rule/IndicatorBoardMetaDataCountShouldNotExceedLimit.rule.ts
+++ b/api/src/numerical-guidance/domain/rule/IndicatorBoardMetaDataCountShouldNotExceedLimit.rule.ts
@@ -3,7 +3,7 @@ import { BusinessRule } from '../../../utils/domain/business.rule';
 const INDICATOR_KEY_MAXIMUM = 5;
 
 export class IndicatorBoardMetaDataCountShouldNotExceedLimitRule implements BusinessRule {
-  constructor(private readonly indicatorIds: Record<string, string[]>) {}
+  constructor(private readonly tickers: Record<string, string[]>) {}
 
   isBroken = () => this.indicatorIds[Object.keys(this.indicatorIds)[0]]?.length > INDICATOR_KEY_MAXIMUM;
 

--- a/api/src/numerical-guidance/domain/rule/IndicatorBoardMetaDataCountShouldNotExceedLimit.rule.ts
+++ b/api/src/numerical-guidance/domain/rule/IndicatorBoardMetaDataCountShouldNotExceedLimit.rule.ts
@@ -5,7 +5,10 @@ const INDICATOR_KEY_MAXIMUM = 5;
 export class IndicatorBoardMetaDataCountShouldNotExceedLimitRule implements BusinessRule {
   constructor(private readonly tickers: Record<string, string[]>) {}
 
-  isBroken = () => this.indicatorIds[Object.keys(this.indicatorIds)[0]]?.length > INDICATOR_KEY_MAXIMUM;
+  isBroken = () =>
+    Object.keys(this.tickers)
+      .map((type) => this.tickers[type].toString().split(',').length)
+      .reduce((accumulator, currentValue) => accumulator + currentValue, 0) > INDICATOR_KEY_MAXIMUM;
 
   get Message() {
     return `지표보드 메타데이터의 개수는 최대 ${INDICATOR_KEY_MAXIMUM}개입니다.`;

--- a/api/src/numerical-guidance/domain/rule/IndicatorBoardMetaDataNameShouldNotEmpty.rule.ts
+++ b/api/src/numerical-guidance/domain/rule/IndicatorBoardMetaDataNameShouldNotEmpty.rule.ts
@@ -4,8 +4,8 @@ export class IndicatorBoardMetaDataNameShouldNotEmptyRule implements BusinessRul
   constructor(private readonly indicatorBoardMetaDataName: string) {}
 
   isBroken = () =>
-    this.indicatorBoardMetaDataName == '' ||
-    this.indicatorBoardMetaDataName.trim() == '' ||
+    this.indicatorBoardMetaDataName === '' ||
+    this.indicatorBoardMetaDataName.trim() === '' ||
     this.indicatorBoardMetaDataName.length === 0 ||
     !this.indicatorBoardMetaDataName;
 

--- a/api/src/numerical-guidance/domain/rule/IndicatorInIndicatorBoardMetadataShouldNotDuplicate.rule.ts
+++ b/api/src/numerical-guidance/domain/rule/IndicatorInIndicatorBoardMetadataShouldNotDuplicate.rule.ts
@@ -1,0 +1,18 @@
+import { BusinessRule } from '../../../utils/domain/business.rule';
+
+export class IndicatorInIndicatorBoardMetadataShouldNotDuplicateRule implements BusinessRule {
+  constructor(private readonly tickers: Record<string, string[]>) {}
+
+  isBroken = () =>
+    Object.keys(this.tickers).some(
+      (type) => this.tickers[type].toString().split(',').length != this.tickersSet(type).size,
+    );
+
+  get Message() {
+    return `지표보드 메타데이터의 지표는 중복될 수 없습니다.`;
+  }
+
+  private tickersSet(type: string) {
+    return new Set(this.tickers[type].toString().split(','));
+  }
+}

--- a/api/src/numerical-guidance/domain/rule/NewIndicatorTypeShouldBelongToTheIndicatorType.rule.ts
+++ b/api/src/numerical-guidance/domain/rule/NewIndicatorTypeShouldBelongToTheIndicatorType.rule.ts
@@ -1,0 +1,12 @@
+import { BusinessRule } from '../../../utils/domain/business.rule';
+
+const INDICATOR_TYPE = ['k-stock', 'exchange'];
+
+export class NewIndicatorTypeShouldBelongToTheIndicatorTypeRule implements BusinessRule {
+  constructor(private readonly tickers: Record<string, string[]>) {}
+
+  isBroken = () => Object.keys(this.tickers).some((type) => !INDICATOR_TYPE.includes(type));
+  get Message() {
+    return `지표의 타입을 올바르게 입력해주세요.`;
+  }
+}

--- a/api/src/numerical-guidance/infrastructure/adapter/persistence/entity/indicator-board-metadata.entity.ts
+++ b/api/src/numerical-guidance/infrastructure/adapter/persistence/entity/indicator-board-metadata.entity.ts
@@ -10,7 +10,7 @@ export class IndicatorBoardMetadataEntity {
   indicatorBoardMetaDataName: string;
 
   @Column({ type: 'hstore', nullable: true })
-  indicators: Record<string, string[]>;
+  tickers: Record<string, string[]>;
 
   @ManyToOne(() => MemberEntity, { eager: false })
   member: MemberEntity;

--- a/api/src/numerical-guidance/infrastructure/adapter/persistence/indicator-board-metadata.persistent.adapter.ts
+++ b/api/src/numerical-guidance/infrastructure/adapter/persistence/indicator-board-metadata.persistent.adapter.ts
@@ -8,10 +8,11 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { AuthService } from '../../../../auth/auth.service';
 import { LoadIndicatorBoardMetadataPort } from 'src/numerical-guidance/application/port/persistence/load-indiactor-board-metadata.port';
+import { InsertIndicatorTickerPort } from '../../../application/port/persistence/insert-indicator-ticker.port';
 
 @Injectable()
 export class IndicatorBoardMetadataPersistentAdapter
-  implements CreateIndicatorBoardMetadataPort, LoadIndicatorBoardMetadataPort
+  implements CreateIndicatorBoardMetadataPort, LoadIndicatorBoardMetadataPort, InsertIndicatorTickerPort
 {
   constructor(
     @InjectRepository(IndicatorBoardMetadataEntity)
@@ -23,30 +24,50 @@ export class IndicatorBoardMetadataPersistentAdapter
     indicatorBoardMetaData: IndicatorBoardMetadata,
     memberId: number,
   ): Promise<string> {
-    const member = await this.authService.findById(memberId);
-
-    const indicatorBoardMetaDataEntity: IndicatorBoardMetadataEntity = IndicatorBoardMetadataMapper.mapDomainToEntity(
-      indicatorBoardMetaData,
-      member,
-    );
-    await this.indicatorBoardMetadataRepository.save(indicatorBoardMetaDataEntity);
-    return indicatorBoardMetaDataEntity.id;
-  }
-
-  async loadIndicatorBoardMetaData(id: string): Promise<IndicatorBoardMetadata> {
     try {
-      const indicatorMetaDataEintity = await this.findOneBy(id);
-      const indicatorBoardMetaData = await IndicatorBoardMetadataMapper.mapEntityToDomain(indicatorMetaDataEintity);
-      return indicatorBoardMetaData;
+      const member = await this.authService.findById(memberId);
+
+      const indicatorBoardMetaDataEntity: IndicatorBoardMetadataEntity = IndicatorBoardMetadataMapper.mapDomainToEntity(
+        indicatorBoardMetaData,
+        member,
+      );
+      await this.indicatorBoardMetadataRepository.save(indicatorBoardMetaDataEntity);
+      return indicatorBoardMetaDataEntity.id;
     } catch (error) {
       throw new BadRequestException({
-        message: 'invalid id',
+        message: '[ERROR] createIndicatorBoardMetaData 중에 문제가 발생했습니다.',
         error: error,
       });
     }
   }
 
-  async findOneBy(id: string) {
-    return this.indicatorBoardMetadataRepository.findOneBy({ id });
+  async loadIndicatorBoardMetaData(id: string): Promise<IndicatorBoardMetadata> {
+    try {
+      const indicatorMetaDataEntity = await this.indicatorBoardMetadataRepository.findOneBy({ id });
+      return await IndicatorBoardMetadataMapper.mapEntityToDomain(indicatorMetaDataEntity);
+    } catch (error) {
+      throw new BadRequestException({
+        message: '[ERROR] loadIndicatorBoardMetaData 중에 문제가 발생했습니다.',
+        error: error,
+      });
+    }
+  }
+
+  async addIndicatorTicker(indicatorBoardMetaData: IndicatorBoardMetadata): Promise<void> {
+    try {
+      const id = indicatorBoardMetaData.id;
+
+      const indicatorBoardMetaDataEntity: IndicatorBoardMetadataEntity =
+        await this.indicatorBoardMetadataRepository.findOneBy({ id });
+
+      indicatorBoardMetaDataEntity.tickers = indicatorBoardMetaData.tickers;
+
+      await this.indicatorBoardMetadataRepository.save(indicatorBoardMetaDataEntity);
+    } catch (error) {
+      throw new BadRequestException({
+        message: '[ERROR] insertIndicator 중에 문제가 발생했습니다.',
+        error: error,
+      });
+    }
   }
 }

--- a/api/src/numerical-guidance/infrastructure/adapter/persistence/mapper/indicator-board-metadata.mapper.ts
+++ b/api/src/numerical-guidance/infrastructure/adapter/persistence/mapper/indicator-board-metadata.mapper.ts
@@ -6,15 +6,16 @@ export class IndicatorBoardMetadataMapper {
   static mapDomainToEntity(indicatorBoardMetaData: IndicatorBoardMetadata, member: MemberEntity) {
     const indicatorBoardMetaDataEntity: IndicatorBoardMetadataEntity = new IndicatorBoardMetadataEntity();
     indicatorBoardMetaDataEntity.indicatorBoardMetaDataName = indicatorBoardMetaData.indicatorBoardMetaDataName;
-    indicatorBoardMetaDataEntity.indicators = indicatorBoardMetaData.indicatorIds;
+    indicatorBoardMetaDataEntity.tickers = indicatorBoardMetaData.tickers;
     indicatorBoardMetaDataEntity.member = member;
     return indicatorBoardMetaDataEntity;
   }
 
   static async mapEntityToDomain(entity: IndicatorBoardMetadataEntity) {
-    const indicatorBoardMetaData = IndicatorBoardMetadata.createNew(
+    const indicatorBoardMetaData = new IndicatorBoardMetadata(
+      entity.id,
       entity.indicatorBoardMetaDataName,
-      entity.indicators,
+      entity.tickers,
     );
     return indicatorBoardMetaData;
   }

--- a/api/src/numerical-guidance/numerical-guidance.module.ts
+++ b/api/src/numerical-guidance/numerical-guidance.module.ts
@@ -15,6 +15,7 @@ import { IndicatorBoardMetadataEntity } from './infrastructure/adapter/persisten
 import { AuthService } from '../auth/auth.service';
 import { MemberEntity } from '../auth/member.entity';
 import { GetIndicatorBoardMetaDataQueryHandler } from './application/query/get-indicator-board-metadata/get-indicator-board-metadata.query.handler';
+import { InsertIndicatorTickerCommandHandler } from './application/command/insert-indicator-ticker/insert-indicator-ticker.command.handler';
 
 @Module({
   imports: [
@@ -35,6 +36,7 @@ import { GetIndicatorBoardMetaDataQueryHandler } from './application/query/get-i
     GetIndicatorListQueryHandler,
     CreateIndicatorBoardMetadataCommandHandler,
     GetIndicatorBoardMetaDataQueryHandler,
+    InsertIndicatorTickerCommandHandler,
     {
       provide: 'LoadCachedFluctuatingIndicatorPort',
       useClass: FluctuatingIndicatorRedisAdapter,
@@ -57,6 +59,10 @@ import { GetIndicatorBoardMetaDataQueryHandler } from './application/query/get-i
     },
     {
       provide: 'LoadIndicatorBoardMetadataPort',
+      useClass: IndicatorBoardMetadataPersistentAdapter,
+    },
+    {
+      provide: 'InsertIndicatorTickerPort',
       useClass: IndicatorBoardMetadataPersistentAdapter,
     },
   ],

--- a/api/src/numerical-guidance/test/E2E test/nemerical-guidance.e2e.spec.ts
+++ b/api/src/numerical-guidance/test/E2E test/nemerical-guidance.e2e.spec.ts
@@ -22,8 +22,8 @@ describe('NumericalGuidance E2E Test', () => {
     const indicatorBoardMetaDataRepository = dataSource.getRepository(IndicatorBoardMetadataEntity);
     await indicatorBoardMetaDataRepository.insert({
       id: '0d73cea1-35a5-432f-bcd1-27ae3541ba73',
-      indicatorBoardMetaDataName: 'ds',
-      indicators: { key1: ['5', '2', '3'] },
+      indicatorBoardMetaDataName: 'name',
+      tickers: { 'k-stock': ['ticker1', 'ticker2'], exchange: [] },
     });
     indicatorBoardMetaDataRepository.save;
   };
@@ -95,8 +95,15 @@ describe('NumericalGuidance E2E Test', () => {
 
   it('/get db에 존재하지않는 메타데이터 id를 전송한다.', () => {
     return request(app.getHttpServer())
-      .get('/numerical-guidance/indicator-board-metadata/invlid-id')
+      .get('/numerical-guidance/indicator-board-metadata/invalid-id')
       .set('Content-Type', 'application/json')
       .expect(HttpStatus.BAD_REQUEST);
+  });
+
+  it('/post db에 존재하지않는 메타데이터 id를 전송한다.', () => {
+    return request(app.getHttpServer())
+      .get('/numerical-guidance/indicator-board-metadata/0d73cea1-35a5-432f-bcd1-27ae3541ba73')
+      .set('Content-Type', 'application/json')
+      .expect(HttpStatus.OK);
   });
 });

--- a/api/src/numerical-guidance/test/E2E test/nemerical-guidance.e2e.spec.ts
+++ b/api/src/numerical-guidance/test/E2E test/nemerical-guidance.e2e.spec.ts
@@ -116,16 +116,9 @@ describe('NumericalGuidance E2E Test', () => {
 
   it('/get db에 존재하지않는 메타데이터 id를 전송한다.', () => {
     return request(app.getHttpServer())
-      .get('/numerical-guidance/indicator-board-metadata/invalid-id')
+      .get('/numerical-guidance/indicator-board-metadata/0d73cea1-35a5-432f-bcd1-27ae3541ba22')
       .set('Content-Type', 'application/json')
-      .expect(HttpStatus.BAD_REQUEST);
-  });
-
-  it('/post db에 존재하지않는 메타데이터 id를 전송한다.', () => {
-    return request(app.getHttpServer())
-      .get('/numerical-guidance/indicator-board-metadata/0d73cea1-35a5-432f-bcd1-27ae3541ba73')
-      .set('Content-Type', 'application/json')
-      .expect(HttpStatus.OK);
+      .expect(HttpStatus.NOT_FOUND);
   });
 
   it('/post 지표보드 메타데이터에 새로운 지표를 추가한다.', async () => {

--- a/api/src/numerical-guidance/test/integration-test/adapter/persistence/indicator-board-metadata.persistent.adapter.spec.ts
+++ b/api/src/numerical-guidance/test/integration-test/adapter/persistence/indicator-board-metadata.persistent.adapter.spec.ts
@@ -113,7 +113,7 @@ describe('IndicatorBoardMetaDataPersistentAdapter', () => {
       await indicatorBoardMetaDataPersistentAdapter.loadIndicatorBoardMetaData('invalidId');
     }).rejects.toThrow(
       new BadRequestException({
-        message: '[ERROR] loadIndicatorBoardMetaData 중에 문제가 발생했습니다.',
+        message: '[ERROR] 지표보드 메타데이터를 불러오는 도중에 오류가 발생했습니다.',
         error: Error,
         HttpStatus: HttpStatus.BAD_REQUEST,
       }),

--- a/api/src/numerical-guidance/test/integration-test/api/numerical-guidance.controller.spec.ts
+++ b/api/src/numerical-guidance/test/integration-test/api/numerical-guidance.controller.spec.ts
@@ -127,15 +127,4 @@ describe('NumericalGuidanceController', () => {
       .set('Content-Type', 'application/json')
       .expect(HttpStatus.BAD_REQUEST);
   });
-
-  // it('/post 메타데이터에 지표 ticker 추가하기.', () => {
-  //   return request(app.getHttpServer())
-  //     .post('/numerical-guidance/indicator-board-metadata/0d73cea1-35a5-432f-bcd1-27ae3541ba73')
-  //     .send({
-  //       ticker: 'ticker1',
-  //       type: 'k-stock',
-  //     })
-  //     .set('Content-Type', 'application/json')
-  //     .expect(HttpStatus.CREATED);
-  // });
 });

--- a/api/src/numerical-guidance/test/integration-test/api/numerical-guidance.controller.spec.ts
+++ b/api/src/numerical-guidance/test/integration-test/api/numerical-guidance.controller.spec.ts
@@ -7,6 +7,7 @@ import { GetFluctuatingIndicatorQueryHandler } from '../../../application/query/
 import { FluctuatingIndicatorDto } from '../../../application/query/get-fluctuatingIndicator/fluctuatingIndicator.dto';
 import { fluctuatingIndicatorTestData } from '../../data/fluctuatingIndicator.test.data';
 import { CreateIndicatorBoardMetadataCommandHandler } from '../../../application/command/create-indicator-board-metadata/create-indicator-board-metadata.command.handler';
+import { InsertIndicatorTickerCommandHandler } from '../../../application/command/insert-indicator-ticker/insert-indicator-ticker.command.handler';
 
 const testData = fluctuatingIndicatorTestData;
 
@@ -25,6 +26,7 @@ describe('NumericalGuidanceController', () => {
         providers: [
           GetFluctuatingIndicatorQueryHandler,
           CreateIndicatorBoardMetadataCommandHandler,
+          InsertIndicatorTickerCommandHandler,
           {
             provide: 'LoadCachedFluctuatingIndicatorPort',
             useValue: {
@@ -51,6 +53,18 @@ describe('NumericalGuidanceController', () => {
             provide: 'CreateIndicatorBoardMetaDataPort',
             useValue: {
               createIndicatorBoardMetaData: jest.fn(),
+            },
+          },
+          {
+            provide: 'LoadIndicatorBoardMetadataPort',
+            useValue: {
+              loadIndicatorBoardMetaData: jest.fn(),
+            },
+          },
+          {
+            provide: 'InsertIndicatorTickerPort',
+            useValue: {
+              addIndicatorTicker: jest.fn(),
             },
           },
         ],
@@ -97,22 +111,31 @@ describe('NumericalGuidanceController', () => {
       .post('/numerical-guidance/indicator-board-metadata')
       .send({
         indicatorBoardMetaDataName: '메타데이터',
-        indicatorIds: { key1: ['1', '2', '3'] },
         memberId: 1,
       })
       .set('Content-Type', 'application/json')
       .expect(HttpStatus.CREATED);
   });
 
-  it('지표보드 메타데이터를 생성할 때 사용자가 유효하지 않는 값 전송한다.', () => {
+  it('/post 지표보드 메타데이터를 생성할 때 사용자가 유효하지 않는 값 전송한다.', () => {
     return request(app.getHttpServer())
       .post('/numerical-guidance/indicator-board-metadata')
       .send({
-        indicatorBoardMetaDataName: '메타데이터',
-        indicatorIds: { key1: ['1', '2', '3', '4', '5', '6'] },
+        indicatorBoardMetaDataName: ' ',
         memberId: 1,
       })
       .set('Content-Type', 'application/json')
       .expect(HttpStatus.BAD_REQUEST);
   });
+
+  // it('/post 메타데이터에 지표 ticker 추가하기.', () => {
+  //   return request(app.getHttpServer())
+  //     .post('/numerical-guidance/indicator-board-metadata/0d73cea1-35a5-432f-bcd1-27ae3541ba73')
+  //     .send({
+  //       ticker: 'ticker1',
+  //       type: 'k-stock',
+  //     })
+  //     .set('Content-Type', 'application/json')
+  //     .expect(HttpStatus.CREATED);
+  // });
 });

--- a/api/src/numerical-guidance/test/unit-test/command/create-indicator-board-metadata.command.handler.spec.ts
+++ b/api/src/numerical-guidance/test/unit-test/command/create-indicator-board-metadata.command.handler.spec.ts
@@ -34,11 +34,7 @@ describe('CreateIndicatorBoardMetaDataCommandHandler', () => {
 
   it('지표보드 메타데이터를 생성한다.', async () => {
     //given
-    const command: CreateIndicatorBoardMetadataCommand = new CreateIndicatorBoardMetadataCommand(
-      '메타데이터',
-      { key1: ['1', '2', '3'] },
-      1,
-    );
+    const command: CreateIndicatorBoardMetadataCommand = new CreateIndicatorBoardMetadataCommand('메타데이터', 1);
 
     //when
     const indicatorBoardMetaData: IndicatorBoardMetadata =

--- a/api/src/numerical-guidance/test/unit-test/command/insert-indicator-ticker.command.handler.spec.ts
+++ b/api/src/numerical-guidance/test/unit-test/command/insert-indicator-ticker.command.handler.spec.ts
@@ -1,0 +1,61 @@
+import { Test } from '@nestjs/testing';
+import { CqrsModule } from '@nestjs/cqrs';
+import { ConfigModule } from '@nestjs/config';
+import { IndicatorBoardMetadata } from '../../../domain/indicator-board-metadata';
+import { InsertIndicatorTickerPort } from '../../../application/port/persistence/insert-indicator-ticker.port';
+import { LoadIndicatorBoardMetadataPort } from '../../../application/port/persistence/load-indiactor-board-metadata.port';
+import { InsertIndicatorTickerCommandHandler } from '../../../application/command/insert-indicator-ticker/insert-indicator-ticker.command.handler';
+import { InsertIndicatorTickerCommand } from '../../../application/command/insert-indicator-ticker/insert-indicator-ticker.command';
+
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => () => ({}),
+}));
+
+describe('InsertIndicatorTickerCommandHandler', () => {
+  let insertIndicatorTickerCommandHandler: InsertIndicatorTickerCommandHandler;
+  let insertIndicatorTickerPort: InsertIndicatorTickerPort;
+  let loadIndicatorBoardMetadataPort: LoadIndicatorBoardMetadataPort;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [CqrsModule, ConfigModule.forRoot()],
+      providers: [
+        InsertIndicatorTickerCommandHandler,
+        {
+          provide: 'InsertIndicatorTickerPort',
+          useValue: {
+            addIndicatorTicker: jest.fn(),
+          },
+        },
+        {
+          provide: 'LoadIndicatorBoardMetadataPort',
+          useValue: {
+            loadIndicatorBoardMetaData: jest.fn().mockImplementation(() => {
+              return new IndicatorBoardMetadata('id', 'name', { 'k-stock': [], exchange: [] });
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    insertIndicatorTickerCommandHandler = module.get(InsertIndicatorTickerCommandHandler);
+    loadIndicatorBoardMetadataPort = module.get('LoadIndicatorBoardMetadataPort');
+    insertIndicatorTickerPort = module.get('InsertIndicatorTickerPort');
+  }, 10000);
+
+  it('지표보드 메타데이터에 지표 ticker를 추가한다.', async () => {
+    //given
+    const indicatorBoardMetadata = await loadIndicatorBoardMetadataPort.loadIndicatorBoardMetaData('id');
+    const command: InsertIndicatorTickerCommand = new InsertIndicatorTickerCommand(
+      indicatorBoardMetadata.id,
+      'ticker',
+      'k-stock',
+    );
+
+    //when
+    await insertIndicatorTickerCommandHandler.execute(command);
+
+    //then
+    expect(insertIndicatorTickerPort.addIndicatorTicker).toHaveBeenCalledTimes(1);
+  });
+});

--- a/api/src/numerical-guidance/test/unit-test/domain/indicator-board-metadata.spec.ts
+++ b/api/src/numerical-guidance/test/unit-test/domain/indicator-board-metadata.spec.ts
@@ -2,32 +2,96 @@ import { IndicatorBoardMetadata } from '../../../domain/indicator-board-metadata
 import { IndicatorBoardMetaDataCountShouldNotExceedLimitRule } from '../../../domain/rule/IndicatorBoardMetaDataCountShouldNotExceedLimit.rule';
 import { BusinessRuleValidationException } from '../../../../utils/domain/business-rule-validation.exception';
 import { IndicatorBoardMetaDataNameShouldNotEmptyRule } from '../../../domain/rule/IndicatorBoardMetaDataNameShouldNotEmpty.rule';
+import { IndicatorInIndicatorBoardMetadataShouldNotDuplicateRule } from '../../../domain/rule/IndicatorInIndicatorBoardMetadataShouldNotDuplicate.rule';
+import { NewIndicatorTypeShouldBelongToTheIndicatorTypeRule } from '../../../domain/rule/NewIndicatorTypeShouldBelongToTheIndicatorType.rule';
 
 describe('지표보드 메타데이터', () => {
-  it('포스트를 게시한다', () => {
+  it('지표보드 메타데이터 도메인 생성', () => {
     // given
 
     // when
-    const indicatorBoardMetaData = IndicatorBoardMetadata.createNew('메타 데이터', { key1: ['1', '2', '3'] });
+    const indicatorBoardMetaData = IndicatorBoardMetadata.createNew('메타 데이터');
 
     // then
-    const expected = new IndicatorBoardMetadata('메타 데이터', { key1: ['1', '2', '3'] });
+    const expected = new IndicatorBoardMetadata(null, '메타 데이터', { 'k-stock': [], exchange: [] });
     expect(expected).toEqual(indicatorBoardMetaData);
   });
 
-  it('지표보드 메타데이터의 개수는 최대 5개를 넘을 수 없다.', () => {
+  it('지표보드 메타데이터에 새로운 지표 ticker 추가', () => {
+    // given
+    const indicatorBoardMetaData = IndicatorBoardMetadata.createNew('name');
+    const type = 'k-stock';
+    const ticker = 'ticker1';
+
+    // when
+    indicatorBoardMetaData.insertIndicatorTicker(ticker, type);
+
+    // then
+    const expected = {
+      'k-stock': ['ticker1'],
+      exchange: [],
+    };
+    expect(expected).toEqual(indicatorBoardMetaData.tickers);
+  });
+
+  it('지표보드 메타데이터의 ticker 개수는 최대 5개를 넘을 수 없다.', () => {
     //given
-    const content = { key1: ['1', '2', '3', '4', '5', '6'] };
+    const indicatorBoardMetaData = new IndicatorBoardMetadata('id1', 'name', {
+      'k-stock': ['ticker1', 'ticker2', 'ticker3'],
+      exchange: ['ticker4', 'ticker5'],
+    });
+    const type = 'k-stock';
+    const ticker = 'ticker6';
 
     //when
-    function createPost() {
-      IndicatorBoardMetadata.createNew('메타 데이터', content);
+    function insertIndicatorTicker() {
+      indicatorBoardMetaData.insertIndicatorTicker(ticker, type);
     }
-    const rule = new IndicatorBoardMetaDataCountShouldNotExceedLimitRule(content);
+    const rule = new IndicatorBoardMetaDataCountShouldNotExceedLimitRule(indicatorBoardMetaData.tickers);
 
     //then
-    expect(createPost).toThrow(BusinessRuleValidationException);
-    expect(createPost).toThrow(rule.Message);
+    expect(insertIndicatorTicker).toThrow(BusinessRuleValidationException);
+    expect(insertIndicatorTicker).toThrow(rule.Message);
+  });
+
+  it('지표보드 메타데이터의 지표 ticker는 중복될 수 없다.', () => {
+    //given
+    const indicatorBoardMetaData = new IndicatorBoardMetadata('id2', 'name', {
+      'k-stock': ['ticker1'],
+      exchange: ['ticker4'],
+    });
+    const type = 'k-stock';
+    const ticker = 'ticker1';
+
+    //when
+    function insertIndicatorTicker() {
+      indicatorBoardMetaData.insertIndicatorTicker(ticker, type);
+    }
+    const rule = new IndicatorInIndicatorBoardMetadataShouldNotDuplicateRule(indicatorBoardMetaData.tickers);
+
+    //then
+    expect(insertIndicatorTicker).toThrow(BusinessRuleValidationException);
+    expect(insertIndicatorTicker).toThrow(rule.Message);
+  });
+
+  it('지표보드 메타데이터의 지표 type 값이 잘못 들어온 경우', () => {
+    //given
+    const indicatorBoardMetaData = new IndicatorBoardMetadata('id3', 'name', {
+      'k-stock': ['ticker1'],
+      exchange: ['ticker4'],
+    });
+    const type = 'invalidType';
+    const ticker = 'ticker3';
+
+    //when
+    function insertIndicatorTicker() {
+      indicatorBoardMetaData.insertIndicatorTicker(ticker, type);
+    }
+    const rule = new NewIndicatorTypeShouldBelongToTheIndicatorTypeRule(indicatorBoardMetaData.tickers);
+
+    //then
+    expect(insertIndicatorTicker).toThrow(BusinessRuleValidationException);
+    expect(insertIndicatorTicker).toThrow(rule.Message);
   });
 
   it('지표보드 메타데이터의 이름은 비워질 수 없다. (빈 문자열인 경우)', () => {
@@ -35,14 +99,14 @@ describe('지표보드 메타데이터', () => {
     const content = '';
 
     //when
-    function createPost() {
-      IndicatorBoardMetadata.createNew(content, { key1: ['1', '2', '3', '4', '5'] });
+    function createNewIndicator() {
+      IndicatorBoardMetadata.createNew(content);
     }
     const rule = new IndicatorBoardMetaDataNameShouldNotEmptyRule(content);
 
     //then
-    expect(createPost).toThrow(BusinessRuleValidationException);
-    expect(createPost).toThrow(rule.Message);
+    expect(createNewIndicator).toThrow(BusinessRuleValidationException);
+    expect(createNewIndicator).toThrow(rule.Message);
   });
 
   it('지표보드 메타데이터의 이름은 비워질 수 없다. (공백으로만 작성한 경우)', () => {
@@ -50,13 +114,13 @@ describe('지표보드 메타데이터', () => {
     const content = '   ';
 
     //when
-    function createPost() {
-      IndicatorBoardMetadata.createNew(content, { key1: ['1', '2', '3', '4', '5'] });
+    function createNewIndicator() {
+      IndicatorBoardMetadata.createNew(content);
     }
     const rule = new IndicatorBoardMetaDataNameShouldNotEmptyRule(content);
 
     //then
-    expect(createPost).toThrow(BusinessRuleValidationException);
-    expect(createPost).toThrow(rule.Message);
+    expect(createNewIndicator).toThrow(BusinessRuleValidationException);
+    expect(createNewIndicator).toThrow(rule.Message);
   });
 });

--- a/api/src/numerical-guidance/test/unit-test/query/get-indicator-board-metadata.query.handler.spec.ts
+++ b/api/src/numerical-guidance/test/unit-test/query/get-indicator-board-metadata.query.handler.spec.ts
@@ -14,7 +14,7 @@ describe('GetIndicatorBoardMetaDataQueryHandler', () => {
           provide: 'LoadIndicatorBoardMetadataPort',
           useValue: {
             loadIndicatorBoardMetaData: jest.fn().mockImplementation(() => {
-              const data = IndicatorBoardMetadata.createNew('메타데이터', { key1: ['1', '2', '3'] });
+              const data = IndicatorBoardMetadata.createNew('메타데이터');
               return data;
             }),
           },
@@ -30,7 +30,7 @@ describe('GetIndicatorBoardMetaDataQueryHandler', () => {
     // when
     const result = await getIndicatorBoardMetadataQueryHandler.execute(testQuery);
     // then
-    const expected = IndicatorBoardMetadata.createNew('메타데이터', { key1: ['1', '2', '3'] });
+    const expected = IndicatorBoardMetadata.createNew('메타데이터');
     expect(result).toEqual(expected);
   });
 });


### PR DESCRIPTION
✅ 작업 내용
- 지표보드 메타데이터에 지표 추가하는 작업을 진행했습니다.
- 지표보드 메타데이터를 초기 생성할 때,  tickers를 빈값으로 생성해주도록 변경했습니다.

## 🤔 고민 했던 부분
- 지표를 추가하는 계층이 어디여야하는지 고민되었고, domain에서 일어나야한다는 것으로 결론지었습니다. 즉, 도메인 계층에서 핵심적인 로직이 이뤄져야한다는 점을 재확인했습니다.
 
## 🔊 도움이 필요한 부분
- 추가해야할 도메인 로직 있다면 편하게 말씀해주세요!