### PR TITLE
[EI-149] live indicator 불러오기

### DIFF
--- a/api/src/numerical-guidance/api/dto/get-live-indicator.dto.ts
+++ b/api/src/numerical-guidance/api/dto/get-live-indicator.dto.ts
@@ -1,0 +1,30 @@
+import { IsString } from 'class-validator';
+import { IsInterval } from '../../../utils/validation/is.interval.validation';
+import { ApiProperty } from '@nestjs/swagger';
+import { Interval, Market } from 'src/utils/type/type-definition';
+import { IsMarket } from 'src/utils/validation/is.market.validation';
+
+export class GetLiveIndicatorDto {
+  @ApiProperty({
+    example: '005930',
+    description: 'KRX 주가 단축코드',
+  })
+  @IsString()
+  readonly ticker: string;
+
+  @ApiProperty({
+    example: 'KOSPI',
+    description: '시장구분',
+  })
+  @IsString()
+  @IsMarket()
+  readonly market: Market;
+
+  @ApiProperty({
+    example: 'day',
+    description: '변동지표 주가 정보의 간격(day, week, month, year)',
+  })
+  @IsString()
+  @IsInterval()
+  readonly interval: Interval;
+}

--- a/api/src/numerical-guidance/api/numerical-guidance.controller.ts
+++ b/api/src/numerical-guidance/api/numerical-guidance.controller.ts
@@ -23,6 +23,8 @@ import { UpdateIndicatorBoardMetadataNameCommand } from '../application/command/
 import { AuthGuard } from '../../auth/auth.guard';
 import { Member } from '../../auth/get-member.decorator';
 import { MemberEntity } from '../../auth/member.entity';
+import { GetLiveIndicatorQuery } from '../application/query/get-live-indicator/get-live-indicator.query';
+import { GetLiveIndicatorDto } from './dto/get-live-indicator.dto';
 
 @ApiTags('NumericalGuidanceController')
 @Controller('/numerical-guidance')
@@ -43,6 +45,17 @@ export class NumericalGuidanceController {
       getFluctuatingIndicatorDto.market,
       getFluctuatingIndicatorDto.interval,
       getFluctuatingIndicatorDto.endDate,
+    );
+    return this.queryBus.execute(query);
+  }
+
+  @ApiOperation({ summary: '고정된 화면에 보여주는 지표 API입니다.' })
+  @Get('/indicators/k-stock/live')
+  async getLiveIndicator(@Query() getLiveIndicatorDto: GetLiveIndicatorDto): Promise<FluctuatingIndicatorDto> {
+    const query = new GetLiveIndicatorQuery(
+      getLiveIndicatorDto.ticker,
+      getLiveIndicatorDto.market,
+      getLiveIndicatorDto.interval,
     );
     return this.queryBus.execute(query);
   }

--- a/api/src/numerical-guidance/application/port/external/load-live-indicator.port.ts
+++ b/api/src/numerical-guidance/application/port/external/load-live-indicator.port.ts
@@ -1,0 +1,5 @@
+import { FluctuatingIndicatorDto } from '../../query/get-fluctuatingIndicator/fluctuatingIndicator.dto';
+
+export interface LoadLiveIndicatorPort {
+  loadLiveIndicator(ticker: string, interval: string, market: string): Promise<FluctuatingIndicatorDto>;
+}

--- a/api/src/numerical-guidance/application/query/get-live-indicator/get-live-indicator.query.handler.ts
+++ b/api/src/numerical-guidance/application/query/get-live-indicator/get-live-indicator.query.handler.ts
@@ -1,0 +1,51 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { GetLiveIndicatorQuery } from './get-live-indicator.query';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { LoadLiveIndicatorPort } from '../../port/external/load-live-indicator.port';
+import { FluctuatingIndicatorDto } from '../get-fluctuatingIndicator/fluctuatingIndicator.dto';
+import { Interval } from '../../../../utils/type/type-definition';
+import { CachingFluctuatingIndicatorPort } from '../../port/cache/caching-fluctuatingIndicator.port';
+import { LoadCachedFluctuatingIndicatorPort } from '../../port/cache/load-cached-fluctuatingIndicator.port';
+
+@Injectable()
+@QueryHandler(GetLiveIndicatorQuery)
+export class GetLiveIndicatorQueryHandler implements IQueryHandler {
+  private readonly logger = new Logger(GetLiveIndicatorQueryHandler.name);
+  constructor(
+    @Inject('LoadLiveIndicatorPort')
+    private readonly loadLiveIndicatorPort: LoadLiveIndicatorPort,
+    @Inject('LoadCachedFluctuatingIndicatorPort')
+    private readonly loadCachedFluctuatingIndicatorPort: LoadCachedFluctuatingIndicatorPort,
+    @Inject('CachingFluctuatingIndicatorPort')
+    private readonly cachingFluctuatingIndicatorPort: CachingFluctuatingIndicatorPort,
+  ) {}
+
+  async execute(query: GetLiveIndicatorQuery): Promise<FluctuatingIndicatorDto> {
+    const { ticker, interval, market } = query;
+
+    const key = this.createLiveIndicatorKey(ticker, interval);
+
+    let fluctuatingIndicatorDto: FluctuatingIndicatorDto =
+      await this.loadCachedFluctuatingIndicatorPort.loadCachedFluctuatingIndicator(key);
+
+    if (this.isNotCached(fluctuatingIndicatorDto)) {
+      fluctuatingIndicatorDto = await this.loadLiveIndicatorPort.loadLiveIndicator(ticker, interval, market);
+      await this.cachingFluctuatingIndicatorPort.cachingFluctuatingIndicator(key, fluctuatingIndicatorDto);
+      this.logger.log('KRX 호출');
+    }
+    return fluctuatingIndicatorDto;
+  }
+
+  private isNotCached(fluctuatingIndicatorDto: FluctuatingIndicatorDto): boolean {
+    return fluctuatingIndicatorDto == null;
+  }
+
+  private createLiveIndicatorKey(ticker: string, interval: Interval) {
+    const today: Date = new Date();
+    const date = `${today.getFullYear()}${(today.getMonth() + 1).toString().padStart(2, '0')}${today
+      .getDate()
+      .toString()
+      .padStart(2, '0')}`;
+    return `live${ticker}${interval}${date}`;
+  }
+}

--- a/api/src/numerical-guidance/application/query/get-live-indicator/get-live-indicator.query.ts
+++ b/api/src/numerical-guidance/application/query/get-live-indicator/get-live-indicator.query.ts
@@ -1,0 +1,10 @@
+import { IQuery } from '@nestjs/cqrs';
+import { Interval, Market } from '../../../../utils/type/type-definition';
+
+export class GetLiveIndicatorQuery implements IQuery {
+  constructor(
+    readonly ticker: string,
+    readonly market: Market,
+    readonly interval: Interval,
+  ) {}
+}

--- a/api/src/numerical-guidance/infrastructure/adapter/krx/fluctuatingIndicator.krx.adapter.ts
+++ b/api/src/numerical-guidance/infrastructure/adapter/krx/fluctuatingIndicator.krx.adapter.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { FluctuatingIndicatorDto } from 'src/numerical-guidance/application/query/get-fluctuatingIndicator/fluctuatingIndicator.dto';
 import { LoadFluctuatingIndicatorPort } from 'src/numerical-guidance/application/port/external/load-fluctuatingIndicator.port';
@@ -6,9 +6,9 @@ import { Interval, Market } from 'src/utils/type/type-definition';
 import { LoadLiveIndicatorPort } from '../../../application/port/external/load-live-indicator.port';
 
 export const DAY_DATA_COUNT = 35;
-export const WEEK_DATA_COUNT = 245;
-export const MONTH_DATA_COUNT = 1050;
-export const YEAR_DATA_COUNT = 12775;
+export const WEEK_DATA_COUNT = 240;
+export const MONTH_DATA_COUNT = 1000;
+export const YEAR_DATA_COUNT = 10000;
 
 @Injectable()
 export class FluctuatingIndicatorKrxAdapter implements LoadFluctuatingIndicatorPort, LoadLiveIndicatorPort {
@@ -69,7 +69,7 @@ export class FluctuatingIndicatorKrxAdapter implements LoadFluctuatingIndicatorP
     const responseData = FluctuatingIndicatorDto.create({ type, numOfRows, pageNo, totalCount, items });
 
     if (!responseData) {
-      throw new Error('API response body is undefined');
+      throw new NotFoundException('[ERROR] API response body is undefined');
     }
     return responseData;
   }

--- a/api/src/numerical-guidance/infrastructure/adapter/krx/fluctuatingIndicator.krx.adapter.ts
+++ b/api/src/numerical-guidance/infrastructure/adapter/krx/fluctuatingIndicator.krx.adapter.ts
@@ -5,10 +5,10 @@ import { LoadFluctuatingIndicatorPort } from 'src/numerical-guidance/application
 import { Interval, Market } from 'src/utils/type/type-definition';
 import { LoadLiveIndicatorPort } from '../../../application/port/external/load-live-indicator.port';
 
-export const DAY_DATA_COUNT = 35;
-export const WEEK_DATA_COUNT = 240;
-export const MONTH_DATA_COUNT = 1000;
-export const YEAR_DATA_COUNT = 10000;
+export const DAY_NUMBER_OF_DAYS = 35;
+export const WEEK_NUMBER_OF_DAYS = 240;
+export const MONTH_NUMBER_OF_DAYS = 1000;
+export const YEAR_NUMBER_OF_DAYS = 10000;
 
 @Injectable()
 export class FluctuatingIndicatorKrxAdapter implements LoadFluctuatingIndicatorPort, LoadLiveIndicatorPort {
@@ -32,20 +32,20 @@ export class FluctuatingIndicatorKrxAdapter implements LoadFluctuatingIndicatorP
     let responseData: FluctuatingIndicatorDto;
     switch (interval) {
       case 'day':
-        startDate = this.getStartDate(endDate, DAY_DATA_COUNT);
-        responseData = await this.createKRXResponseData(DAY_DATA_COUNT, ticker, market, startDate, endDate);
+        startDate = this.getStartDate(endDate, DAY_NUMBER_OF_DAYS);
+        responseData = await this.createKRXResponseData(DAY_NUMBER_OF_DAYS, ticker, market, startDate, endDate);
         break;
       case 'week':
-        startDate = this.getStartDate(endDate, WEEK_DATA_COUNT);
-        responseData = await this.createKRXResponseData(WEEK_DATA_COUNT, ticker, market, startDate, endDate);
+        startDate = this.getStartDate(endDate, WEEK_NUMBER_OF_DAYS);
+        responseData = await this.createKRXResponseData(WEEK_NUMBER_OF_DAYS, ticker, market, startDate, endDate);
         break;
       case 'month':
-        startDate = this.getStartDate(endDate, MONTH_DATA_COUNT);
-        responseData = await this.createKRXResponseData(MONTH_DATA_COUNT, ticker, market, startDate, endDate);
+        startDate = this.getStartDate(endDate, MONTH_NUMBER_OF_DAYS);
+        responseData = await this.createKRXResponseData(MONTH_NUMBER_OF_DAYS, ticker, market, startDate, endDate);
         break;
       case 'year':
-        startDate = this.getStartDate(endDate, YEAR_DATA_COUNT);
-        responseData = await this.createKRXResponseData(YEAR_DATA_COUNT, ticker, market, startDate, endDate);
+        startDate = this.getStartDate(endDate, YEAR_NUMBER_OF_DAYS);
+        responseData = await this.createKRXResponseData(YEAR_NUMBER_OF_DAYS, ticker, market, startDate, endDate);
         break;
     }
 

--- a/api/src/numerical-guidance/numerical-guidance.module.ts
+++ b/api/src/numerical-guidance/numerical-guidance.module.ts
@@ -20,6 +20,7 @@ import { GetMemberIndicatorBoardMetadataListQueryHandler } from './application/q
 import { DeleteIndicatorTickerCommandHandler } from './application/command/delete-indicator-ticker/delete-indicator-ticker.command.handler';
 import { DeleteIndicatorBoardMetadataCommandHandler } from './application/command/delete-indicator-board-metadata/delete-indicator-board-metadata.command.handler';
 import { UpdateIndicatorBoardMetadataNameCommandHandler } from './application/command/update-indicator-board-metadata-name/update-indicator-board-metadata-name.command.handler';
+import { GetLiveIndicatorQueryHandler } from './application/query/get-live-indicator/get-live-indicator.query.handler';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { UpdateIndicatorBoardMetadataNameCommandHandler } from './application/co
   providers: [
     AuthService,
     GetFluctuatingIndicatorQueryHandler,
+    GetLiveIndicatorQueryHandler,
     GetFluctuatingIndicatorWithoutCacheQueryHandler,
     GetIndicatorListQueryHandler,
     CreateIndicatorBoardMetadataCommandHandler,
@@ -51,6 +53,10 @@ import { UpdateIndicatorBoardMetadataNameCommandHandler } from './application/co
     },
     {
       provide: 'LoadFluctuatingIndicatorPort',
+      useClass: FluctuatingIndicatorKrxAdapter,
+    },
+    {
+      provide: 'LoadLiveIndicatorPort',
       useClass: FluctuatingIndicatorKrxAdapter,
     },
     {


### PR DESCRIPTION
✅ 작업 내용
- 고정된 화면에서 live indicator를 보여줄 때 사용하는 api를 작업했습니다.

## 🤔 고민 했던 부분
- 기존의 변동지표를 최소한으로 변경하기 위해 노력했습니다. 
- 기존의 테스트를 깨트리지 않고, 새로운 작업에 대한 변동성을 줄이기 위해 메서드 단위를 세분화했습니다.
- live 지표이기에 가장 최신 지표를 가져오는 endDate를 설정하고 각 interval에 맞는 일 수를 설정해줬습니다. 각 interval에 맞는 일 수에 따라 startDate를 설정함으로써 날짜를 원하는 만큼 설정하도록 했습니다. 이때 dataCount를 넣어주지 않으면 오류가 생겨 추가로 dataCount를 각 interval에 맞는 일 수로 넣어주었습니다. (100일 동안의 데이터가 100개보다 무조건 적으므로 오류 해결 가능)

-> 추가적인 테스트는 저녁에 하게 될거 같아서 미리 올려둡니다..! e2e 테스트와 swagger로는 확인 해둔 상태라 올려요!