### PR TITLE
[EI-171] be 카이젠 빈 객체일 때 로 넘어가는 문제 해결

### DIFF
--- a/api/src/numerical-guidance/api/dto/create-indicator-board-metadata.dto.ts
+++ b/api/src/numerical-guidance/api/dto/create-indicator-board-metadata.dto.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsString } from 'class-validator';
+import { IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateIndicatorBoardMetadataDto {
@@ -8,11 +8,4 @@ export class CreateIndicatorBoardMetadataDto {
   })
   @IsString()
   indicatorBoardMetadataName: string;
-
-  @ApiProperty({
-    example: '1',
-    description: '요청 유저의 pk',
-  })
-  @IsInt()
-  readonly memberId: number;
 }

--- a/api/src/numerical-guidance/api/numerical-guidance.controller.ts
+++ b/api/src/numerical-guidance/api/numerical-guidance.controller.ts
@@ -14,7 +14,6 @@ import { CreateIndicatorBoardMetadataDto } from './dto/create-indicator-board-me
 import { CreateIndicatorBoardMetadataCommand } from '../application/command/create-indicator-board-metadata/create-indicator-board-metadata.command';
 import { Response } from 'express';
 import { GetIndicatorBoardMetadataQuery } from '../application/query/get-indicator-board-metadata/get-indicator-board-metadata.query';
-import { IndicatorBoardMetadata } from '../domain/indicator-board-metadata';
 import { InsertIndicatorIdCommand } from '../application/command/insert-indicator-id/insert-indicator-id.command';
 import { InsertIndicatorDto } from './dto/insert-indicator.dto';
 import { GetIndicatorBoardMetadataListQuery } from '../application/query/get-indicator-board-metadata-list/get-indicator-board-metadata-list.query';
@@ -37,6 +36,7 @@ import { CustomForecastIndicator } from '../domain/custom-forecast-indicator';
 import { GetCustomForecastIndicatorQuery } from '../application/query/get-custom-forecast-indicator/get-custom-forecast-indicator.query';
 import { ApiPaginatedResponseDecorator } from '../../utils/pagination/api-paginated-response.decorator';
 import { ApiExceptionResponse } from '../../utils/exception-filter/api-exception-response.decorator';
+import { IndicatorBoardMetadataDto } from '../application/query/get-indicator-board-metadata/indicator-board-metadata.dto';
 
 @ApiTags('NumericalGuidanceController')
 @Controller('/api/numerical-guidance')
@@ -147,7 +147,7 @@ export class NumericalGuidanceController {
   }
 
   @ApiOperation({ summary: '지표보드 메타데이터 id로 메타데이터를 가져옵니다.' })
-  @ApiOkResponse({ type: IndicatorBoardMetadata })
+  @ApiOkResponse({ type: IndicatorBoardMetadataDto })
   @ApiExceptionResponse(
     400,
     '정보를 불러오는 중에 문제가 발생했습니다. 다시 시도해주세요.',
@@ -170,13 +170,13 @@ export class NumericalGuidanceController {
     required: true,
   })
   @Get('/indicator-board-metadata/:id')
-  async getIndicatorBoardMetadataById(@Param('id') id): Promise<IndicatorBoardMetadata> {
+  async getIndicatorBoardMetadataById(@Param('id') id): Promise<IndicatorBoardMetadataDto> {
     const query = new GetIndicatorBoardMetadataQuery(id);
     return await this.queryBus.execute(query);
   }
 
   @ApiOperation({ summary: '특정 사용자의 member id로 메타데이터 리스트를 가져옵니다.' })
-  @ApiOkResponse({ type: [IndicatorBoardMetadata] })
+  @ApiOkResponse({ type: [IndicatorBoardMetadataDto] })
   @ApiExceptionResponse(
     400,
     '정보를 불러오는 중에 문제가 발생했습니다. 다시 시도해주세요.',
@@ -193,7 +193,7 @@ export class NumericalGuidanceController {
     '[ERROR] 지표를 불러오는 중에 예상치 못한 문제가 발생했습니다.',
   )
   @Get('/indicator-board-metadata')
-  async getIndicatorBoardMetadataListByMember(@Member() member: MemberEntity): Promise<IndicatorBoardMetadata[]> {
+  async getIndicatorBoardMetadataListByMember(@Member() member: MemberEntity): Promise<IndicatorBoardMetadataDto[]> {
     const query = new GetIndicatorBoardMetadataListQuery(member.id);
     return await this.queryBus.execute(query);
   }

--- a/api/src/numerical-guidance/application/command/delete-indicator-id/delete-indicator-id.command.handler.ts
+++ b/api/src/numerical-guidance/application/command/delete-indicator-id/delete-indicator-id.command.handler.ts
@@ -1,10 +1,11 @@
 import { Transactional } from 'typeorm-transactional';
-import { IndicatorBoardMetadata } from '../../../domain/indicator-board-metadata';
 import { LoadIndicatorBoardMetadataPort } from '../../port/persistence/indicator-board-metadata/load-indiactor-board-metadata.port';
 import { DeleteIndicatorIdCommand } from './delete-indicator-id.command';
 import { Inject, Injectable } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { DeleteIndicatorIdPort } from '../../port/persistence/indicator-board-metadata/delete-indicator-id.port';
+import { IndicatorBoardMetadataDto } from '../../query/get-indicator-board-metadata/indicator-board-metadata.dto';
+import { IndicatorBoardMetadataMapper } from '../../../infrastructure/adapter/persistence/indicator-board-metadata/mapper/indicator-board-metadata.mapper';
 
 @Injectable()
 @CommandHandler(DeleteIndicatorIdCommand)
@@ -19,9 +20,9 @@ export class DeleteIndicatorIdCommandHandler implements ICommandHandler {
   @Transactional()
   async execute(command: DeleteIndicatorIdCommand) {
     const { indicatorBoardMetadataId, indicatorId } = command;
-    const indicatorBoardMetadata: IndicatorBoardMetadata =
+    const indicatorBoardMetadataDto: IndicatorBoardMetadataDto =
       await this.loadIndicatorBoardMetadataPort.loadIndicatorBoardMetadata(indicatorBoardMetadataId);
-
+    const indicatorBoardMetadata = IndicatorBoardMetadataMapper.mapDtoToDomain(indicatorBoardMetadataDto);
     indicatorBoardMetadata.deleteIndicatorId(indicatorId);
 
     await this.deleteIndicatorIdPort.deleteIndicatorId(indicatorBoardMetadata);

--- a/api/src/numerical-guidance/application/command/insert-indicator-id/insert-indicator-id.command.handler.ts
+++ b/api/src/numerical-guidance/application/command/insert-indicator-id/insert-indicator-id.command.handler.ts
@@ -4,7 +4,8 @@ import { InsertIndicatorIdPort } from '../../port/persistence/indicator-board-me
 import { Transactional } from 'typeorm-transactional';
 import { InsertIndicatorIdCommand } from './insert-indicator-id.command';
 import { LoadIndicatorBoardMetadataPort } from '../../port/persistence/indicator-board-metadata/load-indiactor-board-metadata.port';
-import { IndicatorBoardMetadata } from '../../../domain/indicator-board-metadata';
+import { IndicatorBoardMetadataDto } from '../../query/get-indicator-board-metadata/indicator-board-metadata.dto';
+import { IndicatorBoardMetadataMapper } from '../../../infrastructure/adapter/persistence/indicator-board-metadata/mapper/indicator-board-metadata.mapper';
 
 @Injectable()
 @CommandHandler(InsertIndicatorIdCommand)
@@ -19,8 +20,9 @@ export class InsertIndicatorIdCommandHandler implements ICommandHandler {
   @Transactional()
   async execute(command: InsertIndicatorIdCommand) {
     const { indicatorBoardMetadataId, indicatorId } = command;
-    const indicatorBoardMetaData: IndicatorBoardMetadata =
+    const indicatorBoardMetadataDto: IndicatorBoardMetadataDto =
       await this.loadIndicatorBoardMetaDataPort.loadIndicatorBoardMetadata(indicatorBoardMetadataId);
+    const indicatorBoardMetaData = IndicatorBoardMetadataMapper.mapDtoToDomain(indicatorBoardMetadataDto);
 
     indicatorBoardMetaData.insertIndicatorId(indicatorId);
 

--- a/api/src/numerical-guidance/application/command/update-indicator-board-metadata-name/update-indicator-board-metadata-name.command.handler.ts
+++ b/api/src/numerical-guidance/application/command/update-indicator-board-metadata-name/update-indicator-board-metadata-name.command.handler.ts
@@ -4,7 +4,8 @@ import { UpdateIndicatorBoardMetadataNameCommand } from './update-indicator-boar
 import { LoadIndicatorBoardMetadataPort } from '../../port/persistence/indicator-board-metadata/load-indiactor-board-metadata.port';
 import { Transactional } from 'typeorm-transactional';
 import { UpdateIndicatorBoardMetadataNamePort } from '../../port/persistence/indicator-board-metadata/update-indicator-board-metadata-name.port';
-import { IndicatorBoardMetadata } from '../../../domain/indicator-board-metadata';
+import { IndicatorBoardMetadataDto } from '../../query/get-indicator-board-metadata/indicator-board-metadata.dto';
+import { IndicatorBoardMetadataMapper } from '../../../infrastructure/adapter/persistence/indicator-board-metadata/mapper/indicator-board-metadata.mapper';
 
 @Injectable()
 @CommandHandler(UpdateIndicatorBoardMetadataNameCommand)
@@ -19,8 +20,9 @@ export class UpdateIndicatorBoardMetadataNameCommandHandler implements ICommandH
   @Transactional()
   async execute(command: UpdateIndicatorBoardMetadataNameCommand) {
     const { id, name } = command;
-    const indicatorBoardMetaData: IndicatorBoardMetadata =
+    const indicatorBoardMetadataDto: IndicatorBoardMetadataDto =
       await this.loadIndicatorBoardMetaDataPort.loadIndicatorBoardMetadata(id);
+    const indicatorBoardMetaData = IndicatorBoardMetadataMapper.mapDtoToDomain(indicatorBoardMetadataDto);
 
     indicatorBoardMetaData.updateIndicatorBoardMetadataName(name);
 

--- a/api/src/numerical-guidance/application/port/persistence/indicator-board-metadata/load-indiactor-board-metadata.port.ts
+++ b/api/src/numerical-guidance/application/port/persistence/indicator-board-metadata/load-indiactor-board-metadata.port.ts
@@ -1,5 +1,5 @@
-import { IndicatorBoardMetadata } from 'src/numerical-guidance/domain/indicator-board-metadata';
+import { IndicatorBoardMetadataDto } from '../../../query/get-indicator-board-metadata/indicator-board-metadata.dto';
 
 export interface LoadIndicatorBoardMetadataPort {
-  loadIndicatorBoardMetadata(id: string): Promise<IndicatorBoardMetadata>;
+  loadIndicatorBoardMetadata(id: string): Promise<IndicatorBoardMetadataDto>;
 }

--- a/api/src/numerical-guidance/application/port/persistence/indicator-board-metadata/load-indicator-board-metadata-list.port.ts
+++ b/api/src/numerical-guidance/application/port/persistence/indicator-board-metadata/load-indicator-board-metadata-list.port.ts
@@ -1,5 +1,5 @@
-import { IndicatorBoardMetadata } from 'src/numerical-guidance/domain/indicator-board-metadata';
+import { IndicatorBoardMetadataDto } from '../../../query/get-indicator-board-metadata/indicator-board-metadata.dto';
 
 export interface LoadIndicatorBoardMetadataListPort {
-  loadIndicatorBoardMetadataList(memberId: number): Promise<IndicatorBoardMetadata[]>;
+  loadIndicatorBoardMetadataList(memberId: number): Promise<IndicatorBoardMetadataDto[]>;
 }

--- a/api/src/numerical-guidance/application/query/get-indicator-board-metadata-list/get-indicator-board-metadata-list.query.handler.ts
+++ b/api/src/numerical-guidance/application/query/get-indicator-board-metadata-list/get-indicator-board-metadata-list.query.handler.ts
@@ -1,8 +1,8 @@
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import { Inject, Injectable } from '@nestjs/common';
-import { IndicatorBoardMetadata } from 'src/numerical-guidance/domain/indicator-board-metadata';
 import { LoadIndicatorBoardMetadataListPort } from '../../port/persistence/indicator-board-metadata/load-indicator-board-metadata-list.port';
 import { GetIndicatorBoardMetadataListQuery } from './get-indicator-board-metadata-list.query';
+import { IndicatorBoardMetadataDto } from '../get-indicator-board-metadata/indicator-board-metadata.dto';
 
 @Injectable()
 @QueryHandler(GetIndicatorBoardMetadataListQuery)
@@ -11,10 +11,8 @@ export class GetIndicatorBoardMetadataListQueryHandler implements IQueryHandler 
     @Inject('LoadIndicatorBoardMetadataListPort')
     private readonly loadIndicatorBoardMetadataPort: LoadIndicatorBoardMetadataListPort,
   ) {}
-  async execute(query: GetIndicatorBoardMetadataListQuery): Promise<IndicatorBoardMetadata[]> {
+  async execute(query: GetIndicatorBoardMetadataListQuery): Promise<IndicatorBoardMetadataDto[]> {
     const memberId = query.memberId;
-    const indicatorBoardMetadataList: IndicatorBoardMetadata[] =
-      await this.loadIndicatorBoardMetadataPort.loadIndicatorBoardMetadataList(memberId);
-    return indicatorBoardMetadataList;
+    return await this.loadIndicatorBoardMetadataPort.loadIndicatorBoardMetadataList(memberId);
   }
 }

--- a/api/src/numerical-guidance/application/query/get-indicator-board-metadata/get-indicator-board-metadata.query.handler.ts
+++ b/api/src/numerical-guidance/application/query/get-indicator-board-metadata/get-indicator-board-metadata.query.handler.ts
@@ -1,8 +1,8 @@
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import { Inject, Injectable } from '@nestjs/common';
 import { GetIndicatorBoardMetadataQuery } from './get-indicator-board-metadata.query';
-import { IndicatorBoardMetadata } from 'src/numerical-guidance/domain/indicator-board-metadata';
 import { LoadIndicatorBoardMetadataPort } from '../../port/persistence/indicator-board-metadata/load-indiactor-board-metadata.port';
+import { IndicatorBoardMetadataDto } from './indicator-board-metadata.dto';
 
 @Injectable()
 @QueryHandler(GetIndicatorBoardMetadataQuery)
@@ -12,10 +12,8 @@ export class GetIndicatorBoardMetadataQueryHandler implements IQueryHandler {
     private readonly loadIndicatorBoardMetadataPort: LoadIndicatorBoardMetadataPort,
   ) {}
 
-  async execute(query: GetIndicatorBoardMetadataQuery): Promise<IndicatorBoardMetadata> {
+  async execute(query: GetIndicatorBoardMetadataQuery): Promise<IndicatorBoardMetadataDto> {
     const id = query.id;
-    const indicatorBoardMetaData: IndicatorBoardMetadata =
-      await this.loadIndicatorBoardMetadataPort.loadIndicatorBoardMetadata(id);
-    return indicatorBoardMetaData;
+    return await this.loadIndicatorBoardMetadataPort.loadIndicatorBoardMetadata(id);
   }
 }

--- a/api/src/numerical-guidance/application/query/get-indicator-board-metadata/indicator-board-metadata.dto.ts
+++ b/api/src/numerical-guidance/application/query/get-indicator-board-metadata/indicator-board-metadata.dto.ts
@@ -1,0 +1,54 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class IndicatorBoardMetadataDto {
+  @ApiProperty({
+    example: 'c6a99067-27d0-4358-b3d5-e63a64b604c0',
+    description: '지표 보드 메티데이터 id',
+  })
+  readonly id: string;
+
+  @ApiProperty({
+    example: 'name',
+    description: '지표 보드 메티데이터 name',
+  })
+  indicatorBoardMetadataName: string;
+
+  @ApiProperty({
+    example: ['c6a99067-27d0-4358-b3d5-e63a64b604c0', 'c6a99067-27d0-4358-b3d5-e63a64b604c3'],
+    description: '지표 id 모음',
+  })
+  indicatorIds: string[];
+
+  @ApiProperty({
+    example: '2024-03-04T05:17:33.756Z',
+    description: '지표 보드 메티데이터 생성일',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    example: '2024-03-04T05:17:33.756Z',
+    description: '지표 보드 메티데이터 수정일',
+  })
+  updatedAt: Date;
+
+  constructor(
+    id: string,
+    indicatorBoardMetadataName: string,
+    indicatorIds: string[],
+    createdAt: Date,
+    updatedAt: Date,
+  ) {
+    this.id = id;
+    this.indicatorBoardMetadataName = indicatorBoardMetadataName;
+    this.indicatorIds = indicatorIds;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  static create({ id, indicatorBoardMetadataName, indicatorIds, createdAt, updatedAt }) {
+    if (indicatorIds.length == 1 && indicatorIds[0] == '') {
+      indicatorIds = [];
+    }
+    return new IndicatorBoardMetadataDto(id, indicatorBoardMetadataName, indicatorIds, createdAt, updatedAt);
+  }
+}

--- a/api/src/numerical-guidance/domain/indicator-board-metadata.ts
+++ b/api/src/numerical-guidance/domain/indicator-board-metadata.ts
@@ -3,42 +3,18 @@ import { IndicatorBoardMetadataCountShouldNotExceedLimitRule } from './rule/Indi
 import { IndicatorBoardMetadataNameShouldNotEmptyRule } from './rule/IndicatorBoardMetadataNameShouldNotEmpty.rule';
 import { IndicatorInIndicatorBoardMetadataShouldNotDuplicateRule } from './rule/IndicatorInIndicatorBoardMetadataShouldNotDuplicate.rule';
 import { OnlyRegisteredIdCanBeRemovedRule } from './rule/OnlyRegisteredIdCanBeRemoved.rule';
-import { ApiProperty } from '@nestjs/swagger';
 
 export class IndicatorBoardMetadata extends AggregateRoot {
-  @ApiProperty({
-    example: 'c6a99067-27d0-4358-b3d5-e63a64b604c0',
-    description: '지표 보드 메티데이터 id',
-  })
   readonly id: string;
-
-  @ApiProperty({
-    example: 'name',
-    description: '지표 보드 메티데이터 name',
-  })
   indicatorBoardMetadataName: string;
-
-  @ApiProperty({
-    example: ['c6a99067-27d0-4358-b3d5-e63a64b604c0', 'c6a99067-27d0-4358-b3d5-e63a64b604c3'],
-    description: '지표 id 모음',
-  })
   indicatorIds: string[];
-
-  @ApiProperty({
-    example: '2024-03-04T05:17:33.756Z',
-    description: '지표 보드 메티데이터 생성일',
-  })
   createdAt: Date;
-
-  @ApiProperty({
-    example: '2024-03-04T05:17:33.756Z',
-    description: '지표 보드 메티데이터 수정일',
-  })
   updatedAt: Date;
 
   static createNew(indicatorBoardMetadataName: string): IndicatorBoardMetadata {
     const initIndicatorIds: string[] = [];
-    return new IndicatorBoardMetadata(null, indicatorBoardMetadataName, initIndicatorIds);
+    const currentDate = new Date();
+    return new IndicatorBoardMetadata(null, indicatorBoardMetadataName, initIndicatorIds, currentDate, currentDate);
   }
 
   public insertIndicatorId(id: string): void {

--- a/api/src/numerical-guidance/domain/indicator-board-metadata.ts
+++ b/api/src/numerical-guidance/domain/indicator-board-metadata.ts
@@ -72,7 +72,13 @@ export class IndicatorBoardMetadata extends AggregateRoot {
     return indicatorIds;
   }
 
-  constructor(id: string, indicatorBoardMetadataName: string, indicatorIds: string[]) {
+  constructor(
+    id: string,
+    indicatorBoardMetadataName: string,
+    indicatorIds: string[],
+    createdAt: Date,
+    updatedAt: Date,
+  ) {
     super();
     this.checkRule(new IndicatorBoardMetadataNameShouldNotEmptyRule(indicatorBoardMetadataName));
     this.checkRule(new IndicatorBoardMetadataCountShouldNotExceedLimitRule(indicatorIds));
@@ -80,7 +86,7 @@ export class IndicatorBoardMetadata extends AggregateRoot {
     this.id = id;
     this.indicatorBoardMetadataName = indicatorBoardMetadataName;
     this.indicatorIds = indicatorIds;
-    this.createdAt = new Date();
-    this.updatedAt = new Date();
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
 }

--- a/api/src/numerical-guidance/infrastructure/adapter/persistence/indicator-board-metadata/indicator-board-metadata.persistent.adapter.ts
+++ b/api/src/numerical-guidance/infrastructure/adapter/persistence/indicator-board-metadata/indicator-board-metadata.persistent.adapter.ts
@@ -21,6 +21,7 @@ import { DeleteIndicatorIdPort } from '../../../../application/port/persistence/
 import { DeleteIndicatorBoardMetadataPort } from '../../../../application/port/persistence/indicator-board-metadata/delete-indicator-board-metadata.port';
 
 import { UpdateIndicatorBoardMetadataNamePort } from '../../../../application/port/persistence/indicator-board-metadata/update-indicator-board-metadata-name.port';
+import { IndicatorBoardMetadataDto } from '../../../../application/query/get-indicator-board-metadata/indicator-board-metadata.dto';
 
 @Injectable()
 export class IndicatorBoardMetadataPersistentAdapter
@@ -73,11 +74,13 @@ export class IndicatorBoardMetadataPersistentAdapter
     }
   }
 
-  async loadIndicatorBoardMetadata(id: string): Promise<IndicatorBoardMetadata> {
+  async loadIndicatorBoardMetadata(id: string): Promise<IndicatorBoardMetadataDto> {
     try {
       const indicatorBoardMetaDataEntity = await this.indicatorBoardMetadataRepository.findOneBy({ id: id });
       this.nullCheckForEntity(indicatorBoardMetaDataEntity);
-      return IndicatorBoardMetadataMapper.mapEntityToDomain(indicatorBoardMetaDataEntity);
+      const indicatorBoardMetaData: IndicatorBoardMetadata =
+        IndicatorBoardMetadataMapper.mapEntityToDomain(indicatorBoardMetaDataEntity);
+      return IndicatorBoardMetadataMapper.mapDomainToDto(indicatorBoardMetaData);
     } catch (error) {
       if (error instanceof NotFoundException) {
         throw new NotFoundException({
@@ -105,7 +108,7 @@ export class IndicatorBoardMetadataPersistentAdapter
     }
   }
 
-  async loadIndicatorBoardMetadataList(memberId): Promise<IndicatorBoardMetadata[]> {
+  async loadIndicatorBoardMetadataList(memberId): Promise<IndicatorBoardMetadataDto[]> {
     try {
       const memberEntity = await this.authService.findById(memberId);
       this.nullCheckForEntity(memberEntity);
@@ -114,8 +117,11 @@ export class IndicatorBoardMetadataPersistentAdapter
         await this.indicatorBoardMetadataRepository.findBy({
           member: memberEntity,
         });
-      return indicatorBoardMetadataEntities.map((entity) => {
+      const indicatorBoardMetadataList: IndicatorBoardMetadata[] = indicatorBoardMetadataEntities.map((entity) => {
         return IndicatorBoardMetadataMapper.mapEntityToDomain(entity);
+      });
+      return indicatorBoardMetadataList.map((domain) => {
+        return IndicatorBoardMetadataMapper.mapDomainToDto(domain);
       });
     } catch (error) {
       if (error instanceof NotFoundException) {

--- a/api/src/numerical-guidance/infrastructure/adapter/persistence/indicator-board-metadata/mapper/indicator-board-metadata.mapper.ts
+++ b/api/src/numerical-guidance/infrastructure/adapter/persistence/indicator-board-metadata/mapper/indicator-board-metadata.mapper.ts
@@ -1,9 +1,13 @@
 import { IndicatorBoardMetadataEntity } from '../entity/indicator-board-metadata.entity';
 import { IndicatorBoardMetadata } from '../../../../../domain/indicator-board-metadata';
 import { MemberEntity } from '../../../../../../auth/member.entity';
+import { IndicatorBoardMetadataDto } from '../../../../../application/query/get-indicator-board-metadata/indicator-board-metadata.dto';
 
 export class IndicatorBoardMetadataMapper {
-  static mapDomainToEntity(indicatorBoardMetaData: IndicatorBoardMetadata, member: MemberEntity) {
+  static mapDomainToEntity(
+    indicatorBoardMetaData: IndicatorBoardMetadata,
+    member: MemberEntity,
+  ): IndicatorBoardMetadataEntity {
     const indicatorBoardMetadataEntity: IndicatorBoardMetadataEntity = new IndicatorBoardMetadataEntity();
     indicatorBoardMetadataEntity.indicatorBoardMetadataName = indicatorBoardMetaData.indicatorBoardMetadataName;
     indicatorBoardMetadataEntity.indicatorIds = { indicatorIds: indicatorBoardMetaData.indicatorIds };
@@ -13,12 +17,33 @@ export class IndicatorBoardMetadataMapper {
     return indicatorBoardMetadataEntity;
   }
 
-  static mapEntityToDomain(entity: IndicatorBoardMetadataEntity) {
-    const indicatorBoardMetadata = new IndicatorBoardMetadata(
+  static mapEntityToDomain(entity: IndicatorBoardMetadataEntity): IndicatorBoardMetadata {
+    return new IndicatorBoardMetadata(
       entity.id,
       entity.indicatorBoardMetadataName,
       entity.indicatorIds['indicatorIds'].toString().split(','),
+      entity.createdAt,
+      entity.updatedAt,
     );
-    return indicatorBoardMetadata;
+  }
+
+  static mapDtoToDomain(dto: IndicatorBoardMetadataDto): IndicatorBoardMetadata {
+    return new IndicatorBoardMetadata(
+      dto.id,
+      dto.indicatorBoardMetadataName,
+      dto.indicatorIds,
+      dto.createdAt,
+      dto.updatedAt,
+    );
+  }
+
+  static mapDomainToDto(domain: IndicatorBoardMetadata): IndicatorBoardMetadataDto {
+    return IndicatorBoardMetadataDto.create({
+      id: domain.id,
+      indicatorBoardMetadataName: domain.indicatorBoardMetadataName,
+      indicatorIds: domain.indicatorIds,
+      createdAt: domain.createdAt,
+      updatedAt: domain.updatedAt,
+    });
   }
 }

--- a/api/src/numerical-guidance/test/integration-test/adapter/persistence/indicator-board-metadata.persistent.adapter.spec.ts
+++ b/api/src/numerical-guidance/test/integration-test/adapter/persistence/indicator-board-metadata.persistent.adapter.spec.ts
@@ -9,6 +9,7 @@ import { PostgreSqlContainer } from '@testcontainers/postgresql';
 import { AuthService } from '../../../../../auth/auth.service';
 import { DataSource } from 'typeorm';
 import { BadRequestException, HttpStatus, NotFoundException } from '@nestjs/common';
+import { IndicatorBoardMetadataDto } from '../../../../application/query/get-indicator-board-metadata/indicator-board-metadata.dto';
 
 jest.mock('typeorm-transactional', () => ({
   Transactional: () => () => ({}),
@@ -123,7 +124,7 @@ describe('IndicatorBoardMetadataPersistentAdapter', () => {
       indicatorBoardMetaData,
       memberId,
     );
-    const resultIndicatorBoardMetaData: IndicatorBoardMetadata =
+    const resultIndicatorBoardMetaData: IndicatorBoardMetadataDto =
       await indicatorBoardMetadataPersistentAdapter.loadIndicatorBoardMetadata(resultId);
 
     // then
@@ -163,7 +164,7 @@ describe('IndicatorBoardMetadataPersistentAdapter', () => {
 
     // then
     const expectedName = '메타 데이터';
-    const expectedIndicatorId = [''];
+    const expectedIndicatorId = [];
 
     expect(result.indicatorBoardMetadataName).toEqual(expectedName);
     expect(result.indicatorIds).toEqual(expectedIndicatorId);
@@ -208,10 +209,13 @@ describe('IndicatorBoardMetadataPersistentAdapter', () => {
 
   it('지표보드 메타데이터에 새로운 지표 id 추가하기.', async () => {
     // given
+    const currentDate = new Date();
     const newIndicatorBoardMetaData: IndicatorBoardMetadata = new IndicatorBoardMetadata(
       '0d73cea1-35a5-432f-bcd1-27ae3541ba73',
       'name',
       ['indicator1', 'indicator2'],
+      currentDate,
+      currentDate,
     );
 
     // when
@@ -273,10 +277,13 @@ describe('IndicatorBoardMetadataPersistentAdapter', () => {
 
   it('지표보드 메타데이터에 새로운 지표 id 추가하기. - DB에 존재하지 않는 경우', async () => {
     // given
+    const currentDate = new Date();
     const newIndicatorBoardMetaData: IndicatorBoardMetadata = new IndicatorBoardMetadata(
       'f2be45ee-d73b-43b6-9344-a8f2264bee41',
       'name',
       ['indicator1', 'indicator2'],
+      currentDate,
+      currentDate,
     );
 
     // when // then
@@ -294,10 +301,13 @@ describe('IndicatorBoardMetadataPersistentAdapter', () => {
 
   it('지표보드 메타데이터에서 지표 삭제하기.', async () => {
     // given
+    const currentDate = new Date();
     const deleteIndicatorBoardMetadata: IndicatorBoardMetadata = new IndicatorBoardMetadata(
       '0d73cea1-35a5-432f-bcd1-27ae3541ba73',
       'name',
       ['indicator1', 'indicator2'],
+      currentDate,
+      currentDate,
     );
 
     // when
@@ -313,10 +323,13 @@ describe('IndicatorBoardMetadataPersistentAdapter', () => {
 
   it('지표보드 메타데이터에서 지표 id 삭제하기. - DB에 존재하지 않는 경우', async () => {
     // given
+    const currentDate = new Date();
     const deleteIndicatorBoardMetadata: IndicatorBoardMetadata = new IndicatorBoardMetadata(
       'e46240d3-7d15-48e7-a9b7-f490bf9ca6e0',
       'name',
       ['indicator1', 'indicator2'],
+      currentDate,
+      currentDate,
     );
 
     // when // then
@@ -389,10 +402,13 @@ describe('IndicatorBoardMetadataPersistentAdapter', () => {
 
   it('지표보드 메타데이터 이름 수정하기.', async () => {
     // given
+    const currentDate = new Date();
     const updateIndicatorBoardMetadata: IndicatorBoardMetadata = new IndicatorBoardMetadata(
       '0d73cea1-35a5-432f-bcd1-27ae3541ba60',
       'updateName',
       ['indicator1', 'indicator2'],
+      currentDate,
+      currentDate,
     );
     // when
     await indicatorBoardMetadataPersistentAdapter.updateIndicatorBoardMetadataName(updateIndicatorBoardMetadata);
@@ -406,10 +422,13 @@ describe('IndicatorBoardMetadataPersistentAdapter', () => {
 
   it('지표보드 메타데이터 이름 수정하기. - DB에 존재하지 않는 경우', async () => {
     // given
+    const currentDate = new Date();
     const invalidIndicatorBoardMetadata: IndicatorBoardMetadata = new IndicatorBoardMetadata(
       'e46240d3-7d15-48e7-a9b7-f490bf9ca6e0',
       'updateName',
       ['indicator1', 'indicator2'],
+      currentDate,
+      currentDate,
     );
 
     // when // then
@@ -427,10 +446,13 @@ describe('IndicatorBoardMetadataPersistentAdapter', () => {
 
   it('지표보드 메타데이터 이름 수정하기. - id 형식이 올바르지 않은 경우', async () => {
     // given
+    const currentDate = new Date();
     const invalidIndicatorBoardMetadata: IndicatorBoardMetadata = new IndicatorBoardMetadata(
       'invalidId',
       'updateName',
       ['indicator1', 'indicator2'],
+      currentDate,
+      currentDate,
     );
 
     // when // then

--- a/api/src/numerical-guidance/test/unit-test/command/delete-indicator-id.command.handler.spec.ts
+++ b/api/src/numerical-guidance/test/unit-test/command/delete-indicator-id.command.handler.spec.ts
@@ -31,7 +31,14 @@ describe('DeleteIndicatorIdCommandHandler', () => {
           provide: 'LoadIndicatorBoardMetadataPort',
           useValue: {
             loadIndicatorBoardMetadata: jest.fn().mockImplementation(() => {
-              return new IndicatorBoardMetadata('id', 'name', ['160e5499-4925-4e38-bb00-8ea6d8056484']);
+              const currentDate = new Date();
+              return new IndicatorBoardMetadata(
+                'id',
+                'name',
+                ['160e5499-4925-4e38-bb00-8ea6d8056484'],
+                currentDate,
+                currentDate,
+              );
             }),
           },
         },

--- a/api/src/numerical-guidance/test/unit-test/command/insert-indicator-id.command.handler.spec.ts
+++ b/api/src/numerical-guidance/test/unit-test/command/insert-indicator-id.command.handler.spec.ts
@@ -31,7 +31,8 @@ describe('InsertIndicatorIdCommandHandler', () => {
           provide: 'LoadIndicatorBoardMetadataPort',
           useValue: {
             loadIndicatorBoardMetadata: jest.fn().mockImplementation(() => {
-              return new IndicatorBoardMetadata('id', 'name', []);
+              const currentDate = new Date();
+              return new IndicatorBoardMetadata('id', 'name', [], currentDate, currentDate);
             }),
           },
         },

--- a/api/src/numerical-guidance/test/unit-test/command/update-indicator-board-metadata-name.command.handler.spec.ts
+++ b/api/src/numerical-guidance/test/unit-test/command/update-indicator-board-metadata-name.command.handler.spec.ts
@@ -31,7 +31,8 @@ describe('UpdateIndicatorBoardMetadataNameCommandHandler', () => {
           provide: 'LoadIndicatorBoardMetadataPort',
           useValue: {
             loadIndicatorBoardMetadata: jest.fn().mockImplementation(() => {
-              return new IndicatorBoardMetadata('id', 'name', []);
+              const currentDate = new Date();
+              return new IndicatorBoardMetadata('id', 'name', [], currentDate, currentDate);
             }),
           },
         },

--- a/api/src/numerical-guidance/test/unit-test/domain/indicator-board-metadata.spec.ts
+++ b/api/src/numerical-guidance/test/unit-test/domain/indicator-board-metadata.spec.ts
@@ -8,12 +8,13 @@ import { OnlyRegisteredIdCanBeRemovedRule } from '../../../domain/rule/OnlyRegis
 describe('지표보드 메타데이터', () => {
   it('지표보드 메타데이터 도메인 생성', () => {
     // given
+    const currentDate = new Date();
 
     // when
     const indicatorBoardMetadata = IndicatorBoardMetadata.createNew('메타 데이터');
 
     // then
-    const expected = new IndicatorBoardMetadata(null, '메타 데이터', []);
+    const expected = new IndicatorBoardMetadata(null, '메타 데이터', [], currentDate, currentDate);
     expect(expected).toEqual(indicatorBoardMetadata);
   });
 
@@ -32,13 +33,14 @@ describe('지표보드 메타데이터', () => {
 
   it('지표보드 메타데이터의 id 개수는 최대 5개를 넘을 수 없다.', () => {
     //given
-    const indicatorBoardMetadata = new IndicatorBoardMetadata('id1', 'name', [
-      'indicatorId1',
-      'indicatorId2',
-      'indicatorId3',
-      'indicatorId4',
-      'indicatorId5',
-    ]);
+    const currentDate = new Date();
+    const indicatorBoardMetadata = new IndicatorBoardMetadata(
+      'id1',
+      'name',
+      ['indicatorId1', 'indicatorId2', 'indicatorId3', 'indicatorId4', 'indicatorId5'],
+      currentDate,
+      currentDate,
+    );
     const indicatorId = 'indicatorId6';
 
     //when
@@ -54,13 +56,14 @@ describe('지표보드 메타데이터', () => {
 
   it('지표보드 메타데이터의 지표 id는 중복될 수 없다.', () => {
     //given
-    const indicatorBoardMetadata = new IndicatorBoardMetadata('id2', 'name', [
-      'indicatorId1',
-      'indicatorId2',
-      'indicatorId3',
-      'indicatorId4',
-      'indicatorId5',
-    ]);
+    const currentDate = new Date();
+    const indicatorBoardMetadata = new IndicatorBoardMetadata(
+      'id2',
+      'name',
+      ['indicatorId1', 'indicatorId2', 'indicatorId3', 'indicatorId4', 'indicatorId5'],
+      currentDate,
+      currentDate,
+    );
     const indicatorId = 'indicatorId1';
 
     //when
@@ -106,13 +109,14 @@ describe('지표보드 메타데이터', () => {
 
   it('지표보드 메타데이터에서 지표 id 삭제', () => {
     // given
-    const indicatorBoardMetadata = new IndicatorBoardMetadata('id1', 'name', [
-      'indicatorId1',
-      'indicatorId2',
-      'indicatorId3',
-      'indicatorId4',
-      'indicatorId5',
-    ]);
+    const currentDate = new Date();
+    const indicatorBoardMetadata = new IndicatorBoardMetadata(
+      'id1',
+      'name',
+      ['indicatorId1', 'indicatorId2', 'indicatorId3', 'indicatorId4', 'indicatorId5'],
+      currentDate,
+      currentDate,
+    );
     const indicatorId = 'indicatorId1';
 
     // when
@@ -125,13 +129,14 @@ describe('지표보드 메타데이터', () => {
 
   it('지표보드 메타데이터에서 지표 id 삭제 - 등록되지 않은 지표 요청', () => {
     // given
-    const indicatorBoardMetadata = new IndicatorBoardMetadata('id1', 'name', [
-      'indicatorId1',
-      'indicatorId2',
-      'indicatorId3',
-      'indicatorId4',
-      'indicatorId5',
-    ]);
+    const currentDate = new Date();
+    const indicatorBoardMetadata = new IndicatorBoardMetadata(
+      'id1',
+      'name',
+      ['indicatorId1', 'indicatorId2', 'indicatorId3', 'indicatorId4', 'indicatorId5'],
+      currentDate,
+      currentDate,
+    );
     const invalidIndicatorId = 'invalidId';
 
     // when
@@ -147,13 +152,14 @@ describe('지표보드 메타데이터', () => {
 
   it('지표보드 메타데이터의 이름을 수정한다. ', () => {
     // given
-    const indicatorBoardMetadata = new IndicatorBoardMetadata('id1', 'name', [
-      'indicatorId1',
-      'indicatorId2',
-      'indicatorId3',
-      'indicatorId4',
-      'indicatorId5',
-    ]);
+    const currentDate = new Date();
+    const indicatorBoardMetadata = new IndicatorBoardMetadata(
+      'id1',
+      'name',
+      ['indicatorId1', 'indicatorId2', 'indicatorId3', 'indicatorId4', 'indicatorId5'],
+      currentDate,
+      currentDate,
+    );
 
     // when
     indicatorBoardMetadata.updateIndicatorBoardMetadataName('updateName');
@@ -165,13 +171,14 @@ describe('지표보드 메타데이터', () => {
 
   it('지표보드 메타데이터의 이름을 수정한다. - 이름이 비어있을 때 ', () => {
     // given
-    const indicatorBoardMetadata = new IndicatorBoardMetadata('id1', 'name', [
-      'indicatorId1',
-      'indicatorId2',
-      'indicatorId3',
-      'indicatorId4',
-      'indicatorId5',
-    ]);
+    const currentDate = new Date();
+    const indicatorBoardMetadata = new IndicatorBoardMetadata(
+      'id1',
+      'name',
+      ['indicatorId1', 'indicatorId2', 'indicatorId3', 'indicatorId4', 'indicatorId5'],
+      currentDate,
+      currentDate,
+    );
     const invalidName = '';
 
     // when

--- a/api/src/numerical-guidance/test/unit-test/query/get-indicator-board-metadata-list.query.handler.spec.ts
+++ b/api/src/numerical-guidance/test/unit-test/query/get-indicator-board-metadata-list.query.handler.spec.ts
@@ -2,6 +2,7 @@ import { Test } from '@nestjs/testing';
 import { GetIndicatorBoardMetadataListQuery } from 'src/numerical-guidance/application/query/get-indicator-board-metadata-list/get-indicator-board-metadata-list.query';
 import { GetIndicatorBoardMetadataListQueryHandler } from 'src/numerical-guidance/application/query/get-indicator-board-metadata-list/get-indicator-board-metadata-list.query.handler';
 import { IndicatorBoardMetadata } from 'src/numerical-guidance/domain/indicator-board-metadata';
+import { IndicatorBoardMetadataDto } from '../../../application/query/get-indicator-board-metadata/indicator-board-metadata.dto';
 
 describe('GetIndicatorBoardMetadataListQueryHandler', () => {
   let getMemberIndicatorBoardMetadataListQueryHandler: GetIndicatorBoardMetadataListQueryHandler;
@@ -27,9 +28,12 @@ describe('GetIndicatorBoardMetadataListQueryHandler', () => {
     // given
     const testQuery = new GetIndicatorBoardMetadataListQuery(1);
     // when
-    const result = await getMemberIndicatorBoardMetadataListQueryHandler.execute(testQuery);
+    const result: IndicatorBoardMetadataDto[] =
+      await getMemberIndicatorBoardMetadataListQueryHandler.execute(testQuery);
     // then
-    const expected = [IndicatorBoardMetadata.createNew('메타데이터')];
-    expect(result).toEqual(expected);
+    const expected: IndicatorBoardMetadata[] = [IndicatorBoardMetadata.createNew('메타데이터')];
+    expect(result.length).toEqual(expected.length);
+    expect(result[0].indicatorBoardMetadataName).toEqual(expected[0].indicatorBoardMetadataName);
+    expect(result[0].indicatorIds).toEqual(expected[0].indicatorIds);
   });
 });


### PR DESCRIPTION
## ✅ 작업 내용
- be 카이젠 빈 객체일 때 로 넘어가는 문제 해결
- 기존에는 createdAt, updatedAt을 생성시점에 new Date()로 추가했었습니다. 이는 DTO -> Domain을 mapping할 때 잘못된 값을 update하게 되므로 외부에서 주입받도록 변경했습니다.