### PR TITLE
[EI-172] be 카이젠 지표보드 메타데이터 빈 객체 수정

### DIFF
--- a/api/src/numerical-guidance/api/dto/create-indicator-board-metadata.dto.ts
+++ b/api/src/numerical-guidance/api/dto/create-indicator-board-metadata.dto.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsString } from 'class-validator';
+import { IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateIndicatorBoardMetadataDto {
@@ -8,11 +8,4 @@ export class CreateIndicatorBoardMetadataDto {
   })
   @IsString()
   indicatorBoardMetadataName: string;
-
-  @ApiProperty({
-    example: '1',
-    description: '요청 유저의 pk',
-  })
-  @IsInt()
-  readonly memberId: number;
 }

--- a/api/src/numerical-guidance/application/query/get-indicator-board-metadata-list/get-indicator-board-metadata-list.query.handler.ts
+++ b/api/src/numerical-guidance/application/query/get-indicator-board-metadata-list/get-indicator-board-metadata-list.query.handler.ts
@@ -1,20 +1,68 @@
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
-import { Inject, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  HttpStatus,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { IndicatorBoardMetadata } from 'src/numerical-guidance/domain/indicator-board-metadata';
-import { LoadIndicatorBoardMetadataListPort } from '../../port/persistence/indicator-board-metadata/load-indicator-board-metadata-list.port';
 import { GetIndicatorBoardMetadataListQuery } from './get-indicator-board-metadata-list.query';
+import { IndicatorBoardMetadataEntity } from '../../../infrastructure/adapter/persistence/indicator-board-metadata/entity/indicator-board-metadata.entity';
+import { IndicatorBoardMetadataMapper } from '../../../infrastructure/adapter/persistence/indicator-board-metadata/mapper/indicator-board-metadata.mapper';
+import { QueryFailedError, Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import { AuthService } from '../../../../auth/auth.service';
 
 @Injectable()
 @QueryHandler(GetIndicatorBoardMetadataListQuery)
 export class GetIndicatorBoardMetadataListQueryHandler implements IQueryHandler {
   constructor(
-    @Inject('LoadIndicatorBoardMetadataListPort')
-    private readonly loadIndicatorBoardMetadataPort: LoadIndicatorBoardMetadataListPort,
+    @InjectRepository(IndicatorBoardMetadataEntity)
+    private readonly indicatorBoardMetadataRepository: Repository<IndicatorBoardMetadataEntity>,
+    private readonly authService: AuthService,
   ) {}
+
   async execute(query: GetIndicatorBoardMetadataListQuery): Promise<IndicatorBoardMetadata[]> {
-    const memberId = query.memberId;
-    const indicatorBoardMetadataList: IndicatorBoardMetadata[] =
-      await this.loadIndicatorBoardMetadataPort.loadIndicatorBoardMetadataList(memberId);
-    return indicatorBoardMetadataList;
+    try {
+      const memberEntity = await this.authService.findById(query.memberId);
+      this.nullCheckForEntity(memberEntity);
+
+      const indicatorBoardMetadataEntities: IndicatorBoardMetadataEntity[] =
+        await this.indicatorBoardMetadataRepository.findBy({
+          member: memberEntity,
+        });
+      return indicatorBoardMetadataEntities.map((entity) => {
+        return IndicatorBoardMetadataMapper.mapEntityToDomain(entity);
+      });
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw new NotFoundException({
+          HttpStatus: HttpStatus.NOT_FOUND,
+          error: `[ERROR] memberId: ${query.memberId} 해당 회원을 찾을 수 없습니다.`,
+          message: '정보를 불러오는 중에 문제가 발생했습니다. 다시 시도해주세요.',
+          cause: error,
+        });
+      }
+      if (error instanceof QueryFailedError) {
+        throw new BadRequestException({
+          HttpStatus: HttpStatus.BAD_REQUEST,
+          error: '[ERROR] 메타데이터 리스트를 불러오는 중 오류가 발생했습니다. member id값이 number인지 확인하세요.',
+          message: '정보를 불러오는 중에 문제가 발생했습니다. 다시 시도해주세요.',
+          cause: error,
+        });
+      } else {
+        throw new InternalServerErrorException({
+          HttpStatus: HttpStatus.INTERNAL_SERVER_ERROR,
+          error: '[ERROR] 지표를 불러오는 중에 예상치 못한 문제가 발생했습니다.',
+          message: '서버에 오류가 발생했습니다. 잠시후 다시 시도해주세요.',
+          cause: error,
+        });
+      }
+    }
+  }
+
+  private nullCheckForEntity(entity) {
+    if (entity == null) throw new NotFoundException();
   }
 }

--- a/api/src/numerical-guidance/application/query/get-indicator-board-metadata/get-indicator-board-metadata.query.handler.ts
+++ b/api/src/numerical-guidance/application/query/get-indicator-board-metadata/get-indicator-board-metadata.query.handler.ts
@@ -1,21 +1,61 @@
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
-import { Inject, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  HttpStatus,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { GetIndicatorBoardMetadataQuery } from './get-indicator-board-metadata.query';
 import { IndicatorBoardMetadata } from 'src/numerical-guidance/domain/indicator-board-metadata';
-import { LoadIndicatorBoardMetadataPort } from '../../port/persistence/indicator-board-metadata/load-indiactor-board-metadata.port';
+import { IndicatorBoardMetadataMapper } from '../../../infrastructure/adapter/persistence/indicator-board-metadata/mapper/indicator-board-metadata.mapper';
+import { TypeORMError } from 'typeorm/error/TypeORMError';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IndicatorBoardMetadataEntity } from '../../../infrastructure/adapter/persistence/indicator-board-metadata/entity/indicator-board-metadata.entity';
+import { Repository } from 'typeorm';
 
 @Injectable()
 @QueryHandler(GetIndicatorBoardMetadataQuery)
 export class GetIndicatorBoardMetadataQueryHandler implements IQueryHandler {
   constructor(
-    @Inject('LoadIndicatorBoardMetadataPort')
-    private readonly loadIndicatorBoardMetadataPort: LoadIndicatorBoardMetadataPort,
+    @InjectRepository(IndicatorBoardMetadataEntity)
+    private readonly indicatorBoardMetadataRepository: Repository<IndicatorBoardMetadataEntity>,
   ) {}
 
   async execute(query: GetIndicatorBoardMetadataQuery): Promise<IndicatorBoardMetadata> {
-    const id = query.id;
-    const indicatorBoardMetaData: IndicatorBoardMetadata =
-      await this.loadIndicatorBoardMetadataPort.loadIndicatorBoardMetadata(id);
-    return indicatorBoardMetaData;
+    try {
+      const indicatorBoardMetaDataEntity = await this.indicatorBoardMetadataRepository.findOneBy({ id: query.id });
+      this.nullCheckForEntity(indicatorBoardMetaDataEntity);
+      console.log(indicatorBoardMetaDataEntity.id);
+      return IndicatorBoardMetadataMapper.mapEntityToDomain(indicatorBoardMetaDataEntity);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw new NotFoundException({
+          HttpStatus: HttpStatus.NOT_FOUND,
+          error: `[ERROR] indicatorBoardMetadataId: ${query.id} 해당 지표보드 메타데이터를 찾을 수 없습니다.`,
+          message: '정보를 불러오는 중에 문제가 발생했습니다. 다시 시도해주세요.',
+          cause: error,
+        });
+      } else if (error instanceof TypeORMError) {
+        throw new BadRequestException({
+          HttpStatus: HttpStatus.BAD_REQUEST,
+          error: `[ERROR] 지표보드 메타데이터를 불러오는 도중에 오류가 발생했습니다.
+          1. id 값이 uuid 형식을 잘 따르고 있는지 확인해주세요.`,
+          message: '정보를 불러오는 중에 문제가 발생했습니다. 다시 시도해주세요.',
+          cause: error,
+        });
+      } else {
+        throw new InternalServerErrorException({
+          HttpStatus: HttpStatus.INTERNAL_SERVER_ERROR,
+          error: '[ERROR] 지표를 불러오는 중에 예상치 못한 문제가 발생했습니다.',
+          message: '서버에 오류가 발생했습니다. 잠시후 다시 시도해주세요.',
+          cause: error,
+        });
+      }
+    }
+  }
+
+  private nullCheckForEntity(entity) {
+    if (entity == null) throw new NotFoundException();
   }
 }

--- a/api/src/numerical-guidance/domain/indicator-board-metadata.ts
+++ b/api/src/numerical-guidance/domain/indicator-board-metadata.ts
@@ -38,7 +38,8 @@ export class IndicatorBoardMetadata extends AggregateRoot {
 
   static createNew(indicatorBoardMetadataName: string): IndicatorBoardMetadata {
     const initIndicatorIds: string[] = [];
-    return new IndicatorBoardMetadata(null, indicatorBoardMetadataName, initIndicatorIds);
+    const currentDate: Date = new Date();
+    return new IndicatorBoardMetadata(null, indicatorBoardMetadataName, initIndicatorIds, currentDate, currentDate);
   }
 
   public insertIndicatorId(id: string): void {
@@ -72,7 +73,13 @@ export class IndicatorBoardMetadata extends AggregateRoot {
     return indicatorIds;
   }
 
-  constructor(id: string, indicatorBoardMetadataName: string, indicatorIds: string[]) {
+  constructor(
+    id: string,
+    indicatorBoardMetadataName: string,
+    indicatorIds: string[],
+    createdAt: Date,
+    updatedAt: Date,
+  ) {
     super();
     this.checkRule(new IndicatorBoardMetadataNameShouldNotEmptyRule(indicatorBoardMetadataName));
     this.checkRule(new IndicatorBoardMetadataCountShouldNotExceedLimitRule(indicatorIds));
@@ -80,7 +87,7 @@ export class IndicatorBoardMetadata extends AggregateRoot {
     this.id = id;
     this.indicatorBoardMetadataName = indicatorBoardMetadataName;
     this.indicatorIds = indicatorIds;
-    this.createdAt = new Date();
-    this.updatedAt = new Date();
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
 }

--- a/api/src/numerical-guidance/infrastructure/adapter/persistence/indicator-board-metadata/mapper/indicator-board-metadata.mapper.ts
+++ b/api/src/numerical-guidance/infrastructure/adapter/persistence/indicator-board-metadata/mapper/indicator-board-metadata.mapper.ts
@@ -18,6 +18,8 @@ export class IndicatorBoardMetadataMapper {
       entity.id,
       entity.indicatorBoardMetadataName,
       this.createArray(entity.indicatorIds['indicatorIds'].toString()),
+      entity.createdAt,
+      entity.updatedAt,
     );
   }
 

--- a/api/src/numerical-guidance/infrastructure/adapter/persistence/indicator-board-metadata/mapper/indicator-board-metadata.mapper.ts
+++ b/api/src/numerical-guidance/infrastructure/adapter/persistence/indicator-board-metadata/mapper/indicator-board-metadata.mapper.ts
@@ -14,11 +14,17 @@ export class IndicatorBoardMetadataMapper {
   }
 
   static mapEntityToDomain(entity: IndicatorBoardMetadataEntity) {
-    const indicatorBoardMetadata = new IndicatorBoardMetadata(
+    return new IndicatorBoardMetadata(
       entity.id,
       entity.indicatorBoardMetadataName,
-      entity.indicatorIds['indicatorIds'].toString().split(','),
+      this.createArray(entity.indicatorIds['indicatorIds'].toString()),
     );
-    return indicatorBoardMetadata;
+  }
+
+  private static createArray(stringArray: string) {
+    if (stringArray.length == 0 || stringArray == '') {
+      return [];
+    }
+    return stringArray.split(',');
   }
 }

--- a/api/src/numerical-guidance/test/integration-test/adapter/persistence/indicator-board-metadata.persistent.adapter.spec.ts
+++ b/api/src/numerical-guidance/test/integration-test/adapter/persistence/indicator-board-metadata.persistent.adapter.spec.ts
@@ -208,10 +208,13 @@ describe('IndicatorBoardMetadataPersistentAdapter', () => {
 
   it('지표보드 메타데이터에 새로운 지표 id 추가하기.', async () => {
     // given
+    const currentDate: Date = new Date();
     const newIndicatorBoardMetaData: IndicatorBoardMetadata = new IndicatorBoardMetadata(
       '0d73cea1-35a5-432f-bcd1-27ae3541ba73',
       'name',
       ['indicator1', 'indicator2'],
+      currentDate,
+      currentDate,
     );
 
     // when
@@ -273,10 +276,13 @@ describe('IndicatorBoardMetadataPersistentAdapter', () => {
 
   it('지표보드 메타데이터에 새로운 지표 id 추가하기. - DB에 존재하지 않는 경우', async () => {
     // given
+    const currentDate: Date = new Date();
     const newIndicatorBoardMetaData: IndicatorBoardMetadata = new IndicatorBoardMetadata(
       'f2be45ee-d73b-43b6-9344-a8f2264bee41',
       'name',
       ['indicator1', 'indicator2'],
+      currentDate,
+      currentDate,
     );
 
     // when // then
@@ -294,10 +300,13 @@ describe('IndicatorBoardMetadataPersistentAdapter', () => {
 
   it('지표보드 메타데이터에서 지표 삭제하기.', async () => {
     // given
+    const currentDate: Date = new Date();
     const deleteIndicatorBoardMetadata: IndicatorBoardMetadata = new IndicatorBoardMetadata(
       '0d73cea1-35a5-432f-bcd1-27ae3541ba73',
       'name',
       ['indicator1', 'indicator2'],
+      currentDate,
+      currentDate,
     );
 
     // when
@@ -313,10 +322,13 @@ describe('IndicatorBoardMetadataPersistentAdapter', () => {
 
   it('지표보드 메타데이터에서 지표 id 삭제하기. - DB에 존재하지 않는 경우', async () => {
     // given
+    const currentDate: Date = new Date();
     const deleteIndicatorBoardMetadata: IndicatorBoardMetadata = new IndicatorBoardMetadata(
       'e46240d3-7d15-48e7-a9b7-f490bf9ca6e0',
       'name',
       ['indicator1', 'indicator2'],
+      currentDate,
+      currentDate,
     );
 
     // when // then
@@ -389,10 +401,13 @@ describe('IndicatorBoardMetadataPersistentAdapter', () => {
 
   it('지표보드 메타데이터 이름 수정하기.', async () => {
     // given
+    const currentDate: Date = new Date();
     const updateIndicatorBoardMetadata: IndicatorBoardMetadata = new IndicatorBoardMetadata(
       '0d73cea1-35a5-432f-bcd1-27ae3541ba60',
       'updateName',
       ['indicator1', 'indicator2'],
+      currentDate,
+      currentDate,
     );
     // when
     await indicatorBoardMetadataPersistentAdapter.updateIndicatorBoardMetadataName(updateIndicatorBoardMetadata);
@@ -406,10 +421,13 @@ describe('IndicatorBoardMetadataPersistentAdapter', () => {
 
   it('지표보드 메타데이터 이름 수정하기. - DB에 존재하지 않는 경우', async () => {
     // given
+    const currentDate: Date = new Date();
     const invalidIndicatorBoardMetadata: IndicatorBoardMetadata = new IndicatorBoardMetadata(
       'e46240d3-7d15-48e7-a9b7-f490bf9ca6e0',
       'updateName',
       ['indicator1', 'indicator2'],
+      currentDate,
+      currentDate,
     );
 
     // when // then
@@ -427,10 +445,13 @@ describe('IndicatorBoardMetadataPersistentAdapter', () => {
 
   it('지표보드 메타데이터 이름 수정하기. - id 형식이 올바르지 않은 경우', async () => {
     // given
+    const currentDate: Date = new Date();
     const invalidIndicatorBoardMetadata: IndicatorBoardMetadata = new IndicatorBoardMetadata(
       'invalidId',
       'updateName',
       ['indicator1', 'indicator2'],
+      currentDate,
+      currentDate,
     );
 
     // when // then

--- a/api/src/numerical-guidance/test/integration-test/adapter/persistence/indicator-board-metadata.persistent.adapter.spec.ts
+++ b/api/src/numerical-guidance/test/integration-test/adapter/persistence/indicator-board-metadata.persistent.adapter.spec.ts
@@ -163,7 +163,7 @@ describe('IndicatorBoardMetadataPersistentAdapter', () => {
 
     // then
     const expectedName = '메타 데이터';
-    const expectedIndicatorId = [''];
+    const expectedIndicatorId = [];
 
     expect(result.indicatorBoardMetadataName).toEqual(expectedName);
     expect(result.indicatorIds).toEqual(expectedIndicatorId);

--- a/api/src/numerical-guidance/test/unit-test/command/delete-indicator-id.command.handler.spec.ts
+++ b/api/src/numerical-guidance/test/unit-test/command/delete-indicator-id.command.handler.spec.ts
@@ -31,7 +31,14 @@ describe('DeleteIndicatorIdCommandHandler', () => {
           provide: 'LoadIndicatorBoardMetadataPort',
           useValue: {
             loadIndicatorBoardMetadata: jest.fn().mockImplementation(() => {
-              return new IndicatorBoardMetadata('id', 'name', ['160e5499-4925-4e38-bb00-8ea6d8056484']);
+              const currentDate: Date = new Date();
+              return new IndicatorBoardMetadata(
+                'id',
+                'name',
+                ['160e5499-4925-4e38-bb00-8ea6d8056484'],
+                currentDate,
+                currentDate,
+              );
             }),
           },
         },

--- a/api/src/numerical-guidance/test/unit-test/command/insert-indicator-id.command.handler.spec.ts
+++ b/api/src/numerical-guidance/test/unit-test/command/insert-indicator-id.command.handler.spec.ts
@@ -31,7 +31,8 @@ describe('InsertIndicatorIdCommandHandler', () => {
           provide: 'LoadIndicatorBoardMetadataPort',
           useValue: {
             loadIndicatorBoardMetadata: jest.fn().mockImplementation(() => {
-              return new IndicatorBoardMetadata('id', 'name', []);
+              const currentDate: Date = new Date();
+              return new IndicatorBoardMetadata('id', 'name', [], currentDate, currentDate);
             }),
           },
         },

--- a/api/src/numerical-guidance/test/unit-test/command/update-indicator-board-metadata-name.command.handler.spec.ts
+++ b/api/src/numerical-guidance/test/unit-test/command/update-indicator-board-metadata-name.command.handler.spec.ts
@@ -31,7 +31,8 @@ describe('UpdateIndicatorBoardMetadataNameCommandHandler', () => {
           provide: 'LoadIndicatorBoardMetadataPort',
           useValue: {
             loadIndicatorBoardMetadata: jest.fn().mockImplementation(() => {
-              return new IndicatorBoardMetadata('id', 'name', []);
+              const currentDate: Date = new Date();
+              return new IndicatorBoardMetadata('id', 'name', [], currentDate, currentDate);
             }),
           },
         },

--- a/api/src/numerical-guidance/test/unit-test/domain/indicator-board-metadata.spec.ts
+++ b/api/src/numerical-guidance/test/unit-test/domain/indicator-board-metadata.spec.ts
@@ -8,12 +8,13 @@ import { OnlyRegisteredIdCanBeRemovedRule } from '../../../domain/rule/OnlyRegis
 describe('지표보드 메타데이터', () => {
   it('지표보드 메타데이터 도메인 생성', () => {
     // given
+    const currentDate: Date = new Date();
 
     // when
     const indicatorBoardMetadata = IndicatorBoardMetadata.createNew('메타 데이터');
 
     // then
-    const expected = new IndicatorBoardMetadata(null, '메타 데이터', []);
+    const expected = new IndicatorBoardMetadata(null, '메타 데이터', [], currentDate, currentDate);
     expect(expected).toEqual(indicatorBoardMetadata);
   });
 
@@ -32,13 +33,14 @@ describe('지표보드 메타데이터', () => {
 
   it('지표보드 메타데이터의 id 개수는 최대 5개를 넘을 수 없다.', () => {
     //given
-    const indicatorBoardMetadata = new IndicatorBoardMetadata('id1', 'name', [
-      'indicatorId1',
-      'indicatorId2',
-      'indicatorId3',
-      'indicatorId4',
-      'indicatorId5',
-    ]);
+    const currentDate: Date = new Date();
+    const indicatorBoardMetadata = new IndicatorBoardMetadata(
+      'id1',
+      'name',
+      ['indicatorId1', 'indicatorId2', 'indicatorId3', 'indicatorId4', 'indicatorId5'],
+      currentDate,
+      currentDate,
+    );
     const indicatorId = 'indicatorId6';
 
     //when
@@ -54,13 +56,14 @@ describe('지표보드 메타데이터', () => {
 
   it('지표보드 메타데이터의 지표 id는 중복될 수 없다.', () => {
     //given
-    const indicatorBoardMetadata = new IndicatorBoardMetadata('id2', 'name', [
-      'indicatorId1',
-      'indicatorId2',
-      'indicatorId3',
-      'indicatorId4',
-      'indicatorId5',
-    ]);
+    const currentDate: Date = new Date();
+    const indicatorBoardMetadata = new IndicatorBoardMetadata(
+      'id2',
+      'name',
+      ['indicatorId1', 'indicatorId2', 'indicatorId3', 'indicatorId4', 'indicatorId5'],
+      currentDate,
+      currentDate,
+    );
     const indicatorId = 'indicatorId1';
 
     //when
@@ -106,13 +109,14 @@ describe('지표보드 메타데이터', () => {
 
   it('지표보드 메타데이터에서 지표 id 삭제', () => {
     // given
-    const indicatorBoardMetadata = new IndicatorBoardMetadata('id1', 'name', [
-      'indicatorId1',
-      'indicatorId2',
-      'indicatorId3',
-      'indicatorId4',
-      'indicatorId5',
-    ]);
+    const currentDate: Date = new Date();
+    const indicatorBoardMetadata = new IndicatorBoardMetadata(
+      'id1',
+      'name',
+      ['indicatorId1', 'indicatorId2', 'indicatorId3', 'indicatorId4', 'indicatorId5'],
+      currentDate,
+      currentDate,
+    );
     const indicatorId = 'indicatorId1';
 
     // when
@@ -125,13 +129,14 @@ describe('지표보드 메타데이터', () => {
 
   it('지표보드 메타데이터에서 지표 id 삭제 - 등록되지 않은 지표 요청', () => {
     // given
-    const indicatorBoardMetadata = new IndicatorBoardMetadata('id1', 'name', [
-      'indicatorId1',
-      'indicatorId2',
-      'indicatorId3',
-      'indicatorId4',
-      'indicatorId5',
-    ]);
+    const currentDate: Date = new Date();
+    const indicatorBoardMetadata = new IndicatorBoardMetadata(
+      'id1',
+      'name',
+      ['indicatorId1', 'indicatorId2', 'indicatorId3', 'indicatorId4', 'indicatorId5'],
+      currentDate,
+      currentDate,
+    );
     const invalidIndicatorId = 'invalidId';
 
     // when
@@ -147,13 +152,14 @@ describe('지표보드 메타데이터', () => {
 
   it('지표보드 메타데이터의 이름을 수정한다. ', () => {
     // given
-    const indicatorBoardMetadata = new IndicatorBoardMetadata('id1', 'name', [
-      'indicatorId1',
-      'indicatorId2',
-      'indicatorId3',
-      'indicatorId4',
-      'indicatorId5',
-    ]);
+    const currentDate: Date = new Date();
+    const indicatorBoardMetadata = new IndicatorBoardMetadata(
+      'id1',
+      'name',
+      ['indicatorId1', 'indicatorId2', 'indicatorId3', 'indicatorId4', 'indicatorId5'],
+      currentDate,
+      currentDate,
+    );
 
     // when
     indicatorBoardMetadata.updateIndicatorBoardMetadataName('updateName');
@@ -165,13 +171,14 @@ describe('지표보드 메타데이터', () => {
 
   it('지표보드 메타데이터의 이름을 수정한다. - 이름이 비어있을 때 ', () => {
     // given
-    const indicatorBoardMetadata = new IndicatorBoardMetadata('id1', 'name', [
-      'indicatorId1',
-      'indicatorId2',
-      'indicatorId3',
-      'indicatorId4',
-      'indicatorId5',
-    ]);
+    const currentDate: Date = new Date();
+    const indicatorBoardMetadata = new IndicatorBoardMetadata(
+      'id1',
+      'name',
+      ['indicatorId1', 'indicatorId2', 'indicatorId3', 'indicatorId4', 'indicatorId5'],
+      currentDate,
+      currentDate,
+    );
     const invalidName = '';
 
     // when

--- a/api/src/numerical-guidance/test/unit-test/query/get-indicator-board-metadata-list.query.handler.spec.ts
+++ b/api/src/numerical-guidance/test/unit-test/query/get-indicator-board-metadata-list.query.handler.spec.ts
@@ -1,35 +1,128 @@
 import { Test } from '@nestjs/testing';
 import { GetIndicatorBoardMetadataListQuery } from 'src/numerical-guidance/application/query/get-indicator-board-metadata-list/get-indicator-board-metadata-list.query';
 import { GetIndicatorBoardMetadataListQueryHandler } from 'src/numerical-guidance/application/query/get-indicator-board-metadata-list/get-indicator-board-metadata-list.query.handler';
-import { IndicatorBoardMetadata } from 'src/numerical-guidance/domain/indicator-board-metadata';
+import { PostgreSqlContainer } from '@testcontainers/postgresql';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MemberEntity } from '../../../../auth/member.entity';
+import { IndicatorBoardMetadataEntity } from '../../../infrastructure/adapter/persistence/indicator-board-metadata/entity/indicator-board-metadata.entity';
+import { AuthService } from '../../../../auth/auth.service';
+import { DataSource } from 'typeorm';
+import { BadRequestException, HttpStatus, NotFoundException } from '@nestjs/common';
+
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => () => ({}),
+}));
 
 describe('GetIndicatorBoardMetadataListQueryHandler', () => {
-  let getMemberIndicatorBoardMetadataListQueryHandler: GetIndicatorBoardMetadataListQueryHandler;
+  let getIndicatorBoardMetadataListQueryHandler: GetIndicatorBoardMetadataListQueryHandler;
+  let environment;
+  let dataSource: DataSource;
 
-  beforeEach(async () => {
+  const seeding = async () => {
+    const memberRepository = dataSource.getRepository(MemberEntity);
+    await memberRepository.insert({ id: 10 });
+    await memberRepository.insert({ id: 5 });
+    await memberRepository.insert({ id: 999 });
+    memberRepository.save;
+
+    const indicatorBoardMetadataRepository = dataSource.getRepository(IndicatorBoardMetadataEntity);
+    await indicatorBoardMetadataRepository.insert({
+      id: '0d73cea1-35a5-432f-bcd1-27ae3541ba73',
+      indicatorBoardMetadataName: '메타데이터',
+      indicatorIds: { indicatorIds: [] },
+      member: { id: 10 },
+    });
+    await indicatorBoardMetadataRepository.insert({
+      id: '0d73cea1-35a5-432f-bcd1-27ae3541ba74',
+      indicatorBoardMetadataName: '메타데이터',
+      indicatorIds: { indicatorIds: [] },
+      member: { id: 10 },
+    });
+  };
+
+  beforeAll(async () => {
+    environment = await new PostgreSqlContainer().start();
     const module = await Test.createTestingModule({
-      providers: [
-        GetIndicatorBoardMetadataListQueryHandler,
-        {
-          provide: 'LoadIndicatorBoardMetadataListPort',
-          useValue: {
-            loadIndicatorBoardMetadataList: jest.fn().mockImplementation(() => {
-              const dataList = [IndicatorBoardMetadata.createNew('메타데이터')];
-              return dataList;
-            }),
-          },
-        },
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+        }),
+        TypeOrmModule.forFeature([MemberEntity, IndicatorBoardMetadataEntity]),
+        TypeOrmModule.forRootAsync({
+          imports: [ConfigModule],
+          inject: [ConfigService],
+          useFactory: () => ({
+            type: 'postgres',
+            retryAttempts: 20,
+            retryDelay: 5000,
+            host: environment.getHost(),
+            port: environment.getPort(),
+            username: environment.getUsername(),
+            password: environment.getPassword(),
+            database: environment.getDatabase(),
+            entities: [IndicatorBoardMetadataEntity, MemberEntity],
+            synchronize: true,
+          }),
+        }),
       ],
+      providers: [GetIndicatorBoardMetadataListQueryHandler, AuthService],
     }).compile();
-    getMemberIndicatorBoardMetadataListQueryHandler = module.get(GetIndicatorBoardMetadataListQueryHandler);
-  }, 10000);
-  it('사용자 id를 가지고 메타데이터를 가져온다.', async () => {
+    getIndicatorBoardMetadataListQueryHandler = module.get(GetIndicatorBoardMetadataListQueryHandler);
+    dataSource = module.get<DataSource>(DataSource);
+    await seeding();
+  }, 20000);
+
+  afterAll(async () => {
+    await environment.stop();
+  });
+
+  it('사용자 id로 메타데이터 리스트 가져오기.', async () => {
     // given
-    const testQuery = new GetIndicatorBoardMetadataListQuery(1);
+    const memberId = 10;
+    const testQuery = new GetIndicatorBoardMetadataListQuery(memberId);
+
     // when
-    const result = await getMemberIndicatorBoardMetadataListQueryHandler.execute(testQuery);
+    const result = await getIndicatorBoardMetadataListQueryHandler.execute(testQuery);
+
     // then
-    const expected = [IndicatorBoardMetadata.createNew('메타데이터')];
-    expect(result).toEqual(expected);
+    const expected = 2;
+    expect(result.length).toEqual(expected);
+  });
+
+  it('사용자 id로 메타데이터 리스트를 가져오기 - 해당 회원이 없을 경우', async () => {
+    // given
+    const invalidId = 111;
+    const testQuery = new GetIndicatorBoardMetadataListQuery(invalidId);
+
+    // when // then
+    await expect(async () => {
+      await getIndicatorBoardMetadataListQueryHandler.execute(testQuery);
+    }).rejects.toThrow(
+      new NotFoundException({
+        HttpStatus: HttpStatus.NOT_FOUND,
+        message: '정보를 불러오는 중에 문제가 발생했습니다. 다시 시도해주세요.',
+        error: `[ERROR] memberId: ${invalidId} 해당 회원을 찾을 수 없습니다.`,
+        cause: Error,
+      }),
+    );
+  });
+
+  it('사용자 id로 메타데이터 리스트를 가져오기 - 유효하지 않은 member id값일 경우', async () => {
+    // given
+    const invalidId = 10.112;
+    const testQuery = new GetIndicatorBoardMetadataListQuery(invalidId);
+
+    // when // then
+    await expect(async () => {
+      await getIndicatorBoardMetadataListQueryHandler.execute(testQuery);
+    }).rejects.toThrow(
+      new BadRequestException({
+        HttpStatus: HttpStatus.BAD_REQUEST,
+        message: '정보를 불러오는 중에 문제가 발생했습니다. 다시 시도해주세요.',
+        error: '[ERROR] 메타데이터 리스트를 불러오는 중 오류가 발생했습니다. member id값이 number인지 확인하세요.',
+        cause: Error,
+      }),
+    );
   });
 });

--- a/api/src/numerical-guidance/test/unit-test/query/get-indicator-board-metadata.query.handler.spec.ts
+++ b/api/src/numerical-guidance/test/unit-test/query/get-indicator-board-metadata.query.handler.spec.ts
@@ -1,36 +1,122 @@
 import { Test } from '@nestjs/testing';
 import { GetIndicatorBoardMetadataQuery } from 'src/numerical-guidance/application/query/get-indicator-board-metadata/get-indicator-board-metadata.query';
 import { GetIndicatorBoardMetadataQueryHandler } from 'src/numerical-guidance/application/query/get-indicator-board-metadata/get-indicator-board-metadata.query.handler';
-import { IndicatorBoardMetadata } from 'src/numerical-guidance/domain/indicator-board-metadata';
+import { BadRequestException, HttpStatus, NotFoundException } from '@nestjs/common';
+import { MemberEntity } from '../../../../auth/member.entity';
+import { IndicatorBoardMetadataEntity } from '../../../infrastructure/adapter/persistence/indicator-board-metadata/entity/indicator-board-metadata.entity';
+import { PostgreSqlContainer } from '@testcontainers/postgresql';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthService } from '../../../../auth/auth.service';
+import { DataSource } from 'typeorm';
+
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => () => ({}),
+}));
 
 describe('GetIndicatorBoardMetadataQueryHandler', () => {
   let getIndicatorBoardMetadataQueryHandler: GetIndicatorBoardMetadataQueryHandler;
+  let environment;
+  let dataSource: DataSource;
 
-  beforeEach(async () => {
+  const seeding = async () => {
+    const memberRepository = dataSource.getRepository(MemberEntity);
+    await memberRepository.insert({ id: 10 });
+    await memberRepository.insert({ id: 5 });
+    await memberRepository.insert({ id: 999 });
+    memberRepository.save;
+
+    const indicatorBoardMetadataRepository = dataSource.getRepository(IndicatorBoardMetadataEntity);
+    await indicatorBoardMetadataRepository.insert({
+      id: '0d73cea1-35a5-432f-bcd1-27ae3541ba73',
+      indicatorBoardMetadataName: '메타데이터',
+      indicatorIds: { indicatorIds: [] },
+      member: { id: 10 },
+    });
+  };
+
+  beforeAll(async () => {
+    environment = await new PostgreSqlContainer().start();
     const module = await Test.createTestingModule({
-      providers: [
-        GetIndicatorBoardMetadataQueryHandler,
-        {
-          provide: 'LoadIndicatorBoardMetadataPort',
-          useValue: {
-            loadIndicatorBoardMetadata: jest.fn().mockImplementation(() => {
-              const data = IndicatorBoardMetadata.createNew('메타데이터');
-              return data;
-            }),
-          },
-        },
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+        }),
+        TypeOrmModule.forFeature([MemberEntity, IndicatorBoardMetadataEntity]),
+        TypeOrmModule.forRootAsync({
+          imports: [ConfigModule],
+          inject: [ConfigService],
+          useFactory: () => ({
+            type: 'postgres',
+            retryAttempts: 20,
+            retryDelay: 5000,
+            host: environment.getHost(),
+            port: environment.getPort(),
+            username: environment.getUsername(),
+            password: environment.getPassword(),
+            database: environment.getDatabase(),
+            entities: [IndicatorBoardMetadataEntity, MemberEntity],
+            synchronize: true,
+          }),
+        }),
       ],
+      providers: [GetIndicatorBoardMetadataQueryHandler, AuthService],
     }).compile();
     getIndicatorBoardMetadataQueryHandler = module.get(GetIndicatorBoardMetadataQueryHandler);
-  }, 10000);
+    dataSource = module.get<DataSource>(DataSource);
+    await seeding();
+  }, 20000);
+
+  afterAll(async () => {
+    await environment.stop();
+  });
 
   it('지표보드 메타데이터 id를 가지고 메타데이터를 가져온다.', async () => {
     // given
-    const testQuery = new GetIndicatorBoardMetadataQuery('uuid');
+    const testQuery = new GetIndicatorBoardMetadataQuery('0d73cea1-35a5-432f-bcd1-27ae3541ba73');
+
     // when
     const result = await getIndicatorBoardMetadataQueryHandler.execute(testQuery);
+
     // then
-    const expected = '메타데이터';
-    expect(result.indicatorBoardMetadataName).toEqual(expected);
+    const expectedName = '메타데이터';
+    const expectedIndicatorIds = [];
+    expect(result.indicatorBoardMetadataName).toEqual(expectedName);
+    expect(result.indicatorIds).toEqual(expectedIndicatorIds);
+  });
+
+  it('지표보드 메타데이터 id로 메타데이터 가져오기 - DB에 존재하지 않는 경우', async () => {
+    // given
+    const invalidQuery = new GetIndicatorBoardMetadataQuery('0d73cea1-35a5-432f-bcd1-27ae3541ba70');
+
+    // when // then
+    await expect(async () => {
+      await getIndicatorBoardMetadataQueryHandler.execute(invalidQuery);
+    }).rejects.toThrow(
+      new NotFoundException({
+        HttpStatus: HttpStatus.NOT_FOUND,
+        message: '정보를 불러오는 중에 문제가 발생했습니다. 다시 시도해주세요.',
+        error: `[ERROR] indicatorBoardMetadataId: ${invalidQuery.id} 해당 지표보드 메타데이터를 찾을 수 없습니다.`,
+        cause: Error,
+      }),
+    );
+  });
+
+  it('지표보드 메타데이터 id로 메타데이터 가져오기 - id 형식이 맞지 않는 경우', async () => {
+    // given
+    const invalidQuery = new GetIndicatorBoardMetadataQuery('invalidId');
+
+    // when // then
+    await expect(async () => {
+      await getIndicatorBoardMetadataQueryHandler.execute(invalidQuery);
+    }).rejects.toThrow(
+      new BadRequestException({
+        HttpStatus: HttpStatus.BAD_REQUEST,
+        message: '정보를 불러오는 중에 문제가 발생했습니다. 다시 시도해주세요.',
+        error: `[ERROR] 지표보드 메타데이터를 불러오는 도중에 오류가 발생했습니다.
+          1. id 값이 uuid 형식을 잘 따르고 있는지 확인해주세요.`,
+        cause: Error,
+      }),
+    );
   });
 });


### PR DESCRIPTION
## ✅ 작업 내용
- 지표보드 메타데이터 빈 객체 수정을 mapper에서 처리하도록 수정했습니다.(도메인에서의 문제가 아니고 데이터를 불러오는 과정, 즉 변환하는 과정의 문제이므로 mapper에서 처리했습니다.)
- 지표보드 메타데이터를 불러오는 query handler는 이제 adapter까지 가지 않아도 직접 DB에 접근합니다.

## 🤔 고민 했던 부분
- 다른 query도 모두 DB를 바로 접근하도록 바꾸려고 했으나, 외부 API를 불러오거나 추가적인 로직(indicatorManger가 사용되는 등)의 이유로 indicatorBoardMetadata만 바꿨습니다.
- 기존에는 createdAt, updatedAt을 생성시점에 new Date()로 추가했었습니다. 이는 entity -> Domain을 mapping할 때 잘못된 값을 update하게 되므로 외부에서 주입받도록 변경했습니다.
