### PR TITLE
[EI-178] historyIndicator dataCount, interval에 따른 값 개수 test 

### DIFF
--- a/api/src/numerical-guidance/api/dto/create-custom-forecast-indicator.dto.ts
+++ b/api/src/numerical-guidance/api/dto/create-custom-forecast-indicator.dto.ts
@@ -2,7 +2,7 @@ import { IsString, IsUUID } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateCustomForecatIndicatorDto {
-  @ApiProperty({ example: '예측지표, ', description: '예측지표 이름' })
+  @ApiProperty({ example: '예측지표', description: '예측지표 이름' })
   @IsString()
   customForecastIndicatorName: string;
 

--- a/api/src/numerical-guidance/test/integration-test/adapter/persistence/history-indicator.persistent.adapter.spec.ts
+++ b/api/src/numerical-guidance/test/integration-test/adapter/persistence/history-indicator.persistent.adapter.spec.ts
@@ -246,4 +246,71 @@ describe('HistoryIndicatorPersistentAdapter', () => {
       }),
     );
   });
+
+  const testDataCounts = [
+    { dataCount: 1 },
+    { dataCount: 2 },
+    { dataCount: 3 },
+    { dataCount: 4 },
+    { dataCount: 5 },
+    { dataCount: 6 },
+    { dataCount: 7 },
+    { dataCount: 8 },
+    { dataCount: 9 },
+    { dataCount: 10 },
+  ];
+
+  it.each(testDataCounts)('history 지표 불러오기 - week 개수 test', async ({ dataCount }) => {
+    // given
+    const { indicatorId, interval, endDate }: GetHistoryIndicatorQuery = {
+      indicatorId: '160e5499-4925-4e38-bb00-8ea6d8056484',
+      interval: 'week',
+      dataCount: dataCount,
+      endDate: '20240227',
+    };
+
+    // when
+    const cursorPageDto: CursorPageDto<HistoryIndicatorDto> =
+      await historyIndicatorPersistentAdapter.loadHistoryIndicator(indicatorId, interval, dataCount, endDate);
+
+    // then
+    const expectedTotalCount = dataCount;
+    expect(expectedTotalCount).toEqual(cursorPageDto.meta.total);
+  });
+
+  it.each(testDataCounts.slice(0, 3))('history 지표 불러오기 - month 개수 test', async ({ dataCount }) => {
+    // given
+    const { indicatorId, interval, endDate }: GetHistoryIndicatorQuery = {
+      indicatorId: '160e5499-4925-4e38-bb00-8ea6d8056484',
+      interval: 'month',
+      dataCount: dataCount,
+      endDate: '20240227',
+    };
+
+    // when
+    const cursorPageDto: CursorPageDto<HistoryIndicatorDto> =
+      await historyIndicatorPersistentAdapter.loadHistoryIndicator(indicatorId, interval, dataCount, endDate);
+
+    // then
+    const expectedTotalCount = dataCount;
+    expect(expectedTotalCount).toEqual(cursorPageDto.meta.total);
+  });
+
+  it.each(testDataCounts.slice(0, 2))('history 지표 불러오기 - year 개수 test', async ({ dataCount }) => {
+    // given
+    const { indicatorId, interval, endDate }: GetHistoryIndicatorQuery = {
+      indicatorId: '160e5499-4925-4e38-bb00-8ea6d8056484',
+      interval: 'year',
+      dataCount: dataCount,
+      endDate: '20240227',
+    };
+
+    // when
+    const cursorPageDto: CursorPageDto<HistoryIndicatorDto> =
+      await historyIndicatorPersistentAdapter.loadHistoryIndicator(indicatorId, interval, dataCount, endDate);
+
+    // then
+    const expectedTotalCount = dataCount;
+    expect(expectedTotalCount).toEqual(cursorPageDto.meta.total);
+  });
 });


### PR DESCRIPTION
## ✅ 작업 내용
- historyIndicator의 개수가 dataCount, interval에 따라서 올바르게 오는 중인지 test를 진행했습니다.

## 🤔 고민 했던 부분
- 여러 개수의 테스트를 진행하고 싶은데 어떻게 해야할까하다가 it.each 라는 테스트 방법이 있더라구요! 이제 여러 값을 한 테스트에서 진행할 수 있어서 훨씬 깔끔하고 정확한 테스트가 가능할거 같습니다!